### PR TITLE
[hotfix] 저금통 디폴트 메시지 저장 안되는 문제 해결, 코어데이터 실패 시 필요에 따라 해당 엔티티 삭제 처리 #193 #197

### DIFF
--- a/Happiggy-bank/Happiggy-bank/ViewController/NewBottleMessageFieldViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/NewBottleMessageFieldViewController.swift
@@ -73,15 +73,17 @@ final class NewBottleMessageFieldViewController: UIViewController {
               let endDate = self.bottleData?.endDate
         else { return false }
         
-        if let openMessage = self.bottleData.openMessage {
-            _ = Bottle(
+        var bottle: Bottle
+        
+        if let openMessage = self.bottleData.openMessage, !openMessage.isEmpty {
+            bottle = Bottle(
                 title: title,
                 startDate: Date(),
                 endDate: endDate,
                 message: openMessage
             )
         } else {
-            _ = Bottle(
+            bottle = Bottle(
                 title: title,
                 startDate: Date(),
                 endDate: endDate,
@@ -103,6 +105,7 @@ final class NewBottleMessageFieldViewController: UIViewController {
             )
         }
         
+        PersistenceStore.shared.delete(bottle)
         self.present(alert, animated: true)
         return false
     }

--- a/Happiggy-bank/Happiggy-bank/ViewController/NewNoteTextViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/NewNoteTextViewController.swift
@@ -260,7 +260,10 @@ final class NewNoteTextViewController: UIViewController {
             let note = self.makeNewNote()
             
             guard self.saveAndPostNewNote() == true
-            else { return }
+            else {
+                PersistenceStore.shared.delete(note)
+                return
+            }
             
             let noteAndDelay = (note: note, delay: CATransition.transitionDuration)
             self.post(name: .noteDidAdd, object: noteAndDelay)


### PR DESCRIPTION
#193 
- #194 풀리퀘스트에서 bottleData.message 에 텍스트필의 값을 넣어주는데, 비어있는 경우 nil 이 아닌 빈 문자열이 저장되어 디폴트 메시지가 적용되기 위한 else 문으로 들어가지 않아서 발생한 문제
  - 조건문에 빈 문자열인지 확인하는 내용을 추가

<br>

#197 
- 위의 상황에서 코어데이터에서 메시지의 최소 길이를 1로 해놔서 빈문자열이 저장되어 코어데이터 에러가 발생. 저장에 실패했더라도 현재 context 자체에는 존재하므로 삭제 처리를 따로 해줘야 해서 추가해줌
