### PR TITLE
[chore] version 1.0.1 업데이트

### DIFF
--- a/Happiggy-bank/Happiggy-bank.xcodeproj/project.pbxproj
+++ b/Happiggy-bank/Happiggy-bank.xcodeproj/project.pbxproj
@@ -928,7 +928,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 04.25.1.0.0;
+				CURRENT_PROJECT_VERSION = 220427.1.0.1;
 				DEVELOPMENT_TEAM = WA6PY6NL25;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Happiggy-bank/Info.plist";
@@ -943,7 +943,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 1.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = Happiggy.HappiggyBank;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "debug-happiggy";
@@ -960,7 +960,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 04.25.1.0.0;
+				CURRENT_PROJECT_VERSION = 220427.1.0.1;
 				DEVELOPMENT_TEAM = WA6PY6NL25;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Happiggy-bank/Info.plist";
@@ -975,7 +975,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 1.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = Happiggy.HappiggyBank;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "TestFlight-appstore-happiggy";


### PR DESCRIPTION
- 저금통 개봉 메시지 저장 안되는 문제 해결
  - 텍스트필드의 값을 적용하지 않고 있어서 발생했던 문제
- 저금통 이름, 메시지에 이모지가 많이 들어가 저금통 애니메이션 뷰에서 한 줄을 초과하는 경우 텍스트가 잘리는 문제 해결
  - 라벨의 줄 수를 모두 0으로 변경하고, 스토리보드에서 오토레이아웃 설정 방식 변경(autoresizing+constraints)
- 코어데이터 오류로 저장에 실패했을 때 필요 시 해당 엔티티 삭제하는 작업 추가
  - 새로운 저금통이나 쪽지를 생성하는 경우에 해당하며, 저장에 실패해도 context 자체에는 계속 존재하기 때문에 필요