### PR TITLE
[chore] 버전 1.0.2 업데이트

### DIFF
--- a/Happiggy-bank/Happiggy-bank.xcodeproj/project.pbxproj
+++ b/Happiggy-bank/Happiggy-bank.xcodeproj/project.pbxproj
@@ -960,7 +960,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 220427.1.0.1;
+				CURRENT_PROJECT_VERSION = 1.0.2;
 				DEVELOPMENT_TEAM = WA6PY6NL25;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Happiggy-bank/Info.plist";
@@ -975,7 +975,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = Happiggy.HappiggyBank;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "debug-happiggy";
@@ -992,7 +992,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 220427.1.0.1;
+				CURRENT_PROJECT_VERSION = 1.0.2;
 				DEVELOPMENT_TEAM = WA6PY6NL25;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Happiggy-bank/Info.plist";
@@ -1007,7 +1007,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = Happiggy.HappiggyBank;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "TestFlight-appstore-happiggy";


### PR DESCRIPTION
- iOS 14로 최소 지원 버전 상향
  - 99%의 유저가 14 이상을 사용하고, 14부터 지원하는 유용한 api가 많아 상향
- 환경설정 탭에 버전 정보 관련 로직 추가(최신 버전입니다 <-> 업데이트가 필요합니다)
- 강제 업데이트 로직 추가
  - 백그라운드에서 포어그라운드로 돌아올 때마다 앱스토어에 올라가 있는 버전의 정보를 가져오도록 함
- 기존 저금통 개봉 후 앱 종료 없이 새로운 저금통 생성 시 쪽지 크기가 달라도 반영되지 않는 버그 해결
  - 그리드를 앱 최초 실행 시에만 초기화해서 발생했던 문제로 새로 생성될 때마다 그리드 초기화하도록 변경