### PR TITLE
[fix] 유저가 업데이트를 해도 환경설정 탭 버전 정보에 업데이트가 필요하다고 뜨는 버그 해결 #221

### DIFF
--- a/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
+++ b/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
@@ -1309,6 +1309,6 @@ extension URL {
     enum StringLiteral {
         
         /// 앱스토어 앱 정보 url
-        static let appInfo = "https://itunes.apple.com/kr/lookup?bundleId=\(bundleID)"
+        static let appInfo = "http://itunes.apple.com/kr/lookup?bundleId=\(bundleID)"
     }
 }

--- a/Happiggy-bank/Happiggy-bank/Utils/VersionManager.swift
+++ b/Happiggy-bank/Happiggy-bank/Utils/VersionManager.swift
@@ -21,7 +21,8 @@ final class VersionManager: VersionChecking {
               let latestVersion = self.latestVersion
         else { return .nil }
         
-        return (installedVersion == latestVersion) ? .false : .true
+        let comparison = installedVersion.compare(latestVersion, options: .numeric)
+        return (comparison == .orderedAscending) ? .true : .false
     }
     
     var needsForcedUpdate: Bool {


### PR DESCRIPTION
- 앱스토어에서 정보를 받아오는 API 주소를 https -> http 로 변경했습니다!
  - http와 https 중 새로운 버전 릴리즈되면 정보 반영이 빠른 게 https 라고 봤는데 http 였나봐요...  