### PR TITLE
[feat] 홈 탭에 더보기 버튼 및 중도 개봉 기능 추가

### DIFF
--- a/Happiggy-bank/Happiggy-bank/Assets.xcassets/button-icon-images/moreButton.imageset/Contents.json
+++ b/Happiggy-bank/Happiggy-bank/Assets.xcassets/button-icon-images/moreButton.imageset/Contents.json
@@ -1,0 +1,25 @@
+{
+  "images" : [
+    {
+      "filename" : "btn_menu.svg",
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "filename" : "btn_menu-2.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "original"
+  }
+}

--- a/Happiggy-bank/Happiggy-bank/Assets.xcassets/button-icon-images/moreButton.imageset/btn_menu-2.svg
+++ b/Happiggy-bank/Happiggy-bank/Assets.xcassets/button-icon-images/moreButton.imageset/btn_menu-2.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="42" viewBox="0 0 24 42" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="12.5" cy="12.5" r="1.5" fill="white"/>
+<circle cx="12.5" cy="21.5" r="1.5" fill="white"/>
+<circle cx="12.5" cy="30.5" r="1.5" fill="white"/>
+</svg>

--- a/Happiggy-bank/Happiggy-bank/Assets.xcassets/button-icon-images/moreButton.imageset/btn_menu.svg
+++ b/Happiggy-bank/Happiggy-bank/Assets.xcassets/button-icon-images/moreButton.imageset/btn_menu.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="42" viewBox="0 0 24 42" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="12.5" cy="12.5" r="1.5" fill="black"/>
+<circle cx="12.5" cy="21.5" r="1.5" fill="black"/>
+<circle cx="12.5" cy="30.5" r="1.5" fill="black"/>
+</svg>

--- a/Happiggy-bank/Happiggy-bank/Extensions/UIAlertController+BasicFormat.swift
+++ b/Happiggy-bank/Happiggy-bank/Extensions/UIAlertController+BasicFormat.swift
@@ -21,7 +21,7 @@ extension UIAlertController {
         let alert = UIAlertController(
             title: alertTitle,
             message: alertMessage,
-            preferredStyle: .alert
+            preferredStyle: preferredStyle
         )
         
         if let confirmAction = confirmAction {

--- a/Happiggy-bank/Happiggy-bank/Storyboard/Base.lproj/Main.storyboard
+++ b/Happiggy-bank/Happiggy-bank/Storyboard/Base.lproj/Main.storyboard
@@ -91,10 +91,15 @@
                                     <constraint firstItem="u5P-Zi-qGu" firstAttribute="top" secondItem="gfd-IP-Gfv" secondAttribute="top" constant="4" id="vgl-Aj-EBu"/>
                                 </constraints>
                             </view>
-                            <button opaque="NO" contentMode="scaleToFill" showsMenuAsPrimaryAction="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4fI-uW-xzV">
-                                <rect key="frame" x="365" y="173.5" width="25" height="24"/>
+                            <button opaque="NO" contentMode="scaleAspectFit" showsMenuAsPrimaryAction="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4fI-uW-xzV">
+                                <rect key="frame" x="344" y="150.5" width="70" height="70"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="70" id="Rg7-L1-U4Z"/>
+                                    <constraint firstAttribute="width" constant="70" id="yL5-Aw-ncE"/>
+                                </constraints>
                                 <state key="normal">
-                                    <imageReference key="image" image="ellipsis.circle" catalog="system" symbolScale="large"/>
+                                    <imageReference key="image" image="moreButton" symbolScale="large"/>
+                                    <preferredSymbolConfiguration key="preferredSymbolConfiguration" scale="default"/>
                                 </state>
                                 <connections>
                                     <action selector="moreButtonDidTap:" destination="BYZ-38-t0r" eventType="touchDown" id="on9-Wv-WIb"/>
@@ -114,7 +119,7 @@
                             <constraint firstItem="dfo-Bk-tQ1" firstAttribute="top" secondItem="8bC-Xf-vdC" secondAttribute="top" id="D8I-Er-tZ3"/>
                             <constraint firstItem="gfd-IP-Gfv" firstAttribute="top" secondItem="Ox7-a2-qYT" secondAttribute="bottom" constant="4" id="EvP-Pn-pVN"/>
                             <constraint firstItem="u5P-Zi-qGu" firstAttribute="leading" secondItem="Ox7-a2-qYT" secondAttribute="leading" id="GH4-Ks-cx0"/>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="4fI-uW-xzV" secondAttribute="trailing" constant="24" id="Kvd-Wm-a7E"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="4fI-uW-xzV" secondAttribute="trailing" id="Kvd-Wm-a7E"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="mxw-FV-eBm" secondAttribute="trailing" symbolic="YES" id="LuX-hH-50l"/>
                             <constraint firstItem="JwR-oy-otr" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="LzX-yn-Ctk"/>
                             <constraint firstItem="ZlX-eS-Yvg" firstAttribute="top" secondItem="8bC-Xf-vdC" secondAttribute="top" id="OFr-if-N9z"/>
@@ -1418,11 +1423,11 @@
         <image name="characterWhite" width="40" height="40"/>
         <image name="characterYellow" width="40" height="40"/>
         <image name="checkmark" width="19" height="16"/>
-        <image name="ellipsis.circle" catalog="system" width="128" height="121"/>
         <image name="fontSelectionExampleBackground" width="327" height="168"/>
         <image name="homeBottleTitleLabel" width="248" height="40"/>
         <image name="homeBottleTitleLabelSmile" width="30" height="30"/>
         <image name="homeCharacter" width="375" height="812"/>
+        <image name="moreButton" width="24" height="42"/>
         <image name="next" width="10" height="18"/>
         <image name="tabBarHomeNormal" width="36" height="26"/>
         <image name="tabBarHomeSelected" width="36" height="26"/>

--- a/Happiggy-bank/Happiggy-bank/Storyboard/Base.lproj/Main.storyboard
+++ b/Happiggy-bank/Happiggy-bank/Storyboard/Base.lproj/Main.storyboard
@@ -4,6 +4,7 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <capability name="Image references" minToolsVersion="12.0"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -90,6 +91,15 @@
                                     <constraint firstItem="u5P-Zi-qGu" firstAttribute="top" secondItem="gfd-IP-Gfv" secondAttribute="top" constant="4" id="vgl-Aj-EBu"/>
                                 </constraints>
                             </view>
+                            <button opaque="NO" contentMode="scaleToFill" showsMenuAsPrimaryAction="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4fI-uW-xzV">
+                                <rect key="frame" x="365" y="173.5" width="25" height="24"/>
+                                <state key="normal">
+                                    <imageReference key="image" image="ellipsis.circle" catalog="system" symbolScale="large"/>
+                                </state>
+                                <connections>
+                                    <action selector="moreButtonDidTap:" destination="BYZ-38-t0r" eventType="touchDown" id="on9-Wv-WIb"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" name="homeBackground"/>
@@ -104,6 +114,7 @@
                             <constraint firstItem="dfo-Bk-tQ1" firstAttribute="top" secondItem="8bC-Xf-vdC" secondAttribute="top" id="D8I-Er-tZ3"/>
                             <constraint firstItem="gfd-IP-Gfv" firstAttribute="top" secondItem="Ox7-a2-qYT" secondAttribute="bottom" constant="4" id="EvP-Pn-pVN"/>
                             <constraint firstItem="u5P-Zi-qGu" firstAttribute="leading" secondItem="Ox7-a2-qYT" secondAttribute="leading" id="GH4-Ks-cx0"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="4fI-uW-xzV" secondAttribute="trailing" constant="24" id="Kvd-Wm-a7E"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="mxw-FV-eBm" secondAttribute="trailing" symbolic="YES" id="LuX-hH-50l"/>
                             <constraint firstItem="JwR-oy-otr" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="LzX-yn-Ctk"/>
                             <constraint firstItem="ZlX-eS-Yvg" firstAttribute="top" secondItem="8bC-Xf-vdC" secondAttribute="top" id="OFr-if-N9z"/>
@@ -111,6 +122,7 @@
                             <constraint firstAttribute="trailing" secondItem="ZlX-eS-Yvg" secondAttribute="trailing" id="OkY-Ki-cEN"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="Ox7-a2-qYT" secondAttribute="trailing" symbolic="YES" id="PEa-7N-X4Y"/>
                             <constraint firstItem="T4r-Fh-6oO" firstAttribute="top" secondItem="mxw-FV-eBm" secondAttribute="bottom" constant="18" id="SPr-4s-61q"/>
+                            <constraint firstItem="4fI-uW-xzV" firstAttribute="centerY" secondItem="Ox7-a2-qYT" secondAttribute="centerY" id="VQt-iI-CDi"/>
                             <constraint firstItem="JwR-oy-otr" firstAttribute="top" secondItem="8bC-Xf-vdC" secondAttribute="bottom" multiplier="498:812" id="Y31-zO-p3W"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="T4r-Fh-6oO" secondAttribute="trailing" symbolic="YES" id="Zz4-tv-PeK"/>
                             <constraint firstItem="mxw-FV-eBm" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="86" id="adg-qC-y3E"/>
@@ -135,6 +147,7 @@
                         <outlet property="emptyTopLabel" destination="mxw-FV-eBm" id="p3m-Ek-xyl"/>
                         <outlet property="homeCharacter" destination="dfo-Bk-tQ1" id="pAM-Ay-Jl4"/>
                         <outlet property="homeView" destination="8bC-Xf-vdC" id="edO-Zc-7da"/>
+                        <outlet property="moreButton" destination="4fI-uW-xzV" id="aOr-ry-QUT"/>
                         <outlet property="tapToAddNoteLabel" destination="JwR-oy-otr" id="Slp-Bm-aZ3"/>
                         <segue destination="abG-42-vcb" kind="presentation" identifier="presentNewBottleNameField" id="aZQ-BA-T0f"/>
                         <segue destination="moi-e1-3hQ" kind="presentation" identifier="presentNewNoteDatePicker" id="5ln-YY-tck"/>
@@ -178,17 +191,17 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <view contentMode="scaleToFill" verticalHuggingPriority="249" id="hvx-Jx-SEb">
-                                <rect key="frame" x="0.0" y="372" width="414" height="152"/>
+                                <rect key="frame" x="0.0" y="372" width="414" height="151"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES" flexibleMaxY="YES"/>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" alpha="0.0" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="화면을 탭 하면 리스트로 넘어갑니다." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3XN-7E-k3f">
-                                <rect key="frame" x="106.5" y="540" width="201" height="17"/>
+                                <rect key="frame" x="106.5" y="539" width="201" height="17"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <color key="textColor" name="secondaryLabelColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" alpha="0.0" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PmD-gO-jD3">
-                                <rect key="frame" x="181" y="581" width="52" height="26.5"/>
+                                <rect key="frame" x="181" y="580" width="52" height="26.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="22"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -1405,6 +1418,7 @@
         <image name="characterWhite" width="40" height="40"/>
         <image name="characterYellow" width="40" height="40"/>
         <image name="checkmark" width="19" height="16"/>
+        <image name="ellipsis.circle" catalog="system" width="128" height="121"/>
         <image name="fontSelectionExampleBackground" width="327" height="168"/>
         <image name="homeBottleTitleLabel" width="248" height="40"/>
         <image name="homeBottleTitleLabelSmile" width="30" height="30"/>

--- a/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
+++ b/Happiggy-bank/Happiggy-bank/Utils/Constants.swift
@@ -28,7 +28,7 @@ extension HomeViewController {
         
         /// 버튼 길이(높이와 동일)
         static let buttonWidth: CGFloat = buttonHeight
-
+        
         /// Bottle Label의 Border Width
         static let bottleLabelBorderWidth: CGFloat = 1
         
@@ -52,15 +52,6 @@ extension HomeViewController {
     /// 문자열
     enum StringLiteral {
         
-        /// 저금통 개봉 확인 알림 제목
-        static let bottleOpenAlertTitle = "저금통 개봉날이에요! 개봉하시겠어요?"
-        
-        ///
-        static let bottleOpenAlertMessage = "현재 저금통 모습이 그대로 저장됩니다"
-        
-        /// 저금통 개봉 확인 알림 개봉 버튼 제목
-        static let bottleOpenAlertOpenButtonTitle = "개봉"
-        
         /// 저금통이 없는 경우 나타나는 상단 라벨 문자열
         static let emptyTopLabelText: String = "저금통이 없습니다."
         
@@ -81,12 +72,16 @@ extension HomeViewController {
         
         /// 작성 가능한 날짜가 없음을 알리는 알람의 제목
         static let noEmptyDateAlertTitle = "이미 모든 날짜에 행복을 기록했어요"
-
+        
         /// 작성 가능한 날짜가 없음을 알리는 알람의 메시지
         static let noEmptyDateAlertMessage = "미래의 날짜는 작성 불가능합니다."
         
         /// 저금통이 없을 때 나타나는 캐릭터 이미지 이름
         static let homeCharacterEmpty = "homeCharacter"
+        
+        /// 더보기 버튼을 눌러서 저금통 개봉이 가능함을 알리는 알림의 제목
+        static let tapMoreButtonToOpenBottleAlertTitle =
+        "오른쪽 위 더보기 버튼을 눌러 저금통을 개봉할 수 있어요!"
     }
     
     /// 폰트 크기
@@ -94,6 +89,75 @@ extension HomeViewController {
         
         /// 기한이 지났는데 저금통을 열지 않은 경우 나타내는 라벨 폰트 크기
         static let openDatePassedLabelFont: CGFloat = 15
+    }
+    
+    /// 저금통 개봉 알림 관련 문자열
+    enum BottleOpenAlert {
+        
+        /// 디데이 이후 개봉하는 경우
+        case `default`
+        
+        /// 디데이 전에 개봉하는 경우
+        case midOpen
+        
+        /// 알림 제목
+        var title: String {
+            switch self {
+            case .default:
+                return "저금통 개봉날이에요! 개봉하시겠어요?"
+            case .midOpen:
+                return "지금 저금통을 개봉하시겠어요?"
+            }
+        }
+        
+        /// 알림 메시지
+        var message: String {
+            switch self {
+            case .default:
+                return "현재 저금통 모습이 그대로 저장됩니다"
+            case .midOpen:
+                return """
+중도 개봉 시 더 이상 추가로 작성할 수 없으며,
+현재 저금통 모습이 그대로 저장됩니다
+"""
+            }
+        }
+        
+        /// 저금통 개봉 확인 알림 개봉 버튼 제목
+        static let openButtonTitle = "개봉"
+    }
+    
+    /// 더보기 버튼
+    enum MoreButton {
+        /// 저금통 이름 변경
+        case changeBottleName
+        /// 저금통 개봉
+        case openBottle(BottleStatus)
+        
+        /// 아이템 별 제목
+        var title: String {
+            switch self {
+            case .changeBottleName:
+                return "이름 변경"
+            case .openBottle(let bottleStatus):
+                if bottleStatus == .inProgress {
+                    return "중도 개봉"
+                }
+                if bottleStatus == .complete {
+                    return "개봉"
+                }
+                return .empty
+            }
+        }
+    }
+    
+    /// 저금통 상태
+    enum BottleStatus {
+        /// 진행 중
+        case inProgress
+        
+        /// 디데이 지남
+        case complete
     }
 }
 
@@ -134,7 +198,7 @@ extension BottleViewModel {
 }
 
 extension DefaultButton {
-
+    
     /// HomeViewButton 에서 설정하는 layout에 적용할 상수값
     enum Metric {
         
@@ -244,7 +308,7 @@ extension BottleCell {
     
     /// Bottle Cell에서 설정하는 layout 상수값
     enum Metric {
-
+        
         /// bottle  image 가로:세로 비율
         private static let imageSizeRatio: CGFloat = 306 / 165
         
@@ -288,7 +352,7 @@ extension Bottle {
     
     /// Bottle 엔티티에서 설정하는 문자열
     enum StringLiteral {
-
+        
         /// 제목 디폴트 값: "?"
         static let title = "?"
         
@@ -313,7 +377,7 @@ extension Note {
     
     /// Note 엔티티에서 설정하는 문자열
     enum StringLiteral {
-
+        
         /// 내용 디폴트 값: "?"
         static let content = "?"
     }
@@ -437,7 +501,7 @@ extension NewBottleNameFieldViewController {
         
         /// 하단 라벨 텍스트 크기
         static let bottomLabelText: CGFloat = 14
-    
+        
         /// 경고 라벨 텍스트 색상
         static let warningLabelText: CGFloat = 14
     }
@@ -541,7 +605,7 @@ enum Asset: String {
     
     /// 탭바 환경설정 아이콘 보통 상태
     case tabBarSettingsNormal
-
+    
     /// 탭바 홈 아이콘 선택 상태
     case tabBarHomeSelected
     
@@ -550,7 +614,7 @@ enum Asset: String {
     
     /// 탭바 환경설정 아이콘 선택 상태
     case tabBarSettingsSelected
-
+    
     
     // MARK: Home View Images
     
@@ -577,10 +641,10 @@ enum Asset: String {
     
     /// 저금통 리스트 셀 라이트 모드 배경화면
     case bottleCellBackgroundLight
-
+    
     /// 저금통 리스트 저금통 뒷면
     case bottleListBottleBack
-
+    
     /// 저금통 리스트 저금통 앞면
     case bottleListBottleFront
     
@@ -665,7 +729,7 @@ extension NewNoteTextViewController {
             let navigationBarHeight = navigationBarFrame.size.height
             let screenHeight = UIScreen.main.bounds.height
             let safeAreaTopInset = navigationBarFrame.origin.y
-
+            
             return screenHeight - safeAreaTopInset - navigationBarHeight - keyboardHeight
         }
         
@@ -963,13 +1027,12 @@ extension BottleMessageViewController {
         
         /// 탭 안내 라벨 딜레이: 0.5
         static let tapToContinueLabelDelay: TimeInterval = 0.5
-
+        
         /// 탭 안내 라벨 시간: 1.5
         static let tapToContinueLabel: TimeInterval = 1.5
         
         /// 페이드인 상대시간: 3/4
         static let tapToContinueLabelRelativeFadeIn: TimeInterval = 3/4
-
     }
     
     /// 문자열
@@ -980,6 +1043,12 @@ extension BottleMessageViewController {
         
         /// UserDefaults의 key로 사용할 문자열
         static let hasNotificationOn: String = "hasNotificationOn"
+    }
+    
+    /// 숫자
+    enum Metric {
+        /// 1
+        static let one = 1
     }
 }
 
@@ -1121,7 +1190,7 @@ extension BottleNameEditViewController {
         
         /// 하단 라벨 텍스트 크기
         static let bottomLabelText: CGFloat = 14
-    
+
         /// 경고 라벨 텍스트 색상
         static let warningLabelText: CGFloat = 14
     }

--- a/Happiggy-bank/Happiggy-bank/ViewController/BottleMessageViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/BottleMessageViewController.swift
@@ -184,6 +184,7 @@ final class BottleMessageViewController: UIViewController {
     /// 저금통 상태를 업데이트하고 다른 뷰 컨트롤러로 이동
     private func saveBottleUpdates() -> Bool {
         self.bottle.isOpen.toggle()
+        self.updateBottleEndDateIfNeeded()
         removeAllNotifications()
         
         if self.bottle.notes.isEmpty {
@@ -223,5 +224,18 @@ final class BottleMessageViewController: UIViewController {
         center.removeAllDeliveredNotifications()
         center.removeAllPendingNotificationRequests()
         UserDefaults.standard.set(false, forKey: StringLiteral.hasNotificationOn)
+    }
+    
+    /// 중도 개봉인 경우 종료 날짜 변경
+    private func updateBottleEndDateIfNeeded() {
+        guard self.bottle.isInProgress
+        else { return }
+        
+        let startOfTomorrow = Calendar.current.date(
+            byAdding: .day,
+            value: Metric.one,
+            to: Calendar.current.startOfDay(for: Date())
+        )
+        bottle.endDate_ = startOfTomorrow
     }
 }

--- a/Happiggy-bank/Happiggy-bank/ViewController/HomeViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/HomeViewController.swift
@@ -378,7 +378,12 @@ final class HomeViewController: UIViewController {
     /// 더보기 버튼의 저금통 개봉 아이템 설정
     private func configureOpenBottleItem(forBottle bottle: Bottle) -> UIAction {
         let title = MoreButton.openBottle(bottle.isInProgress ? .inProgress : .complete).title
-        let attributes = bottle.isInProgress ? UIMenuElement.Attributes.destructive : []
+        var attributes: UIMenuElement.Attributes = []
+        
+        if bottle.isInProgress {
+            attributes = (Date() >= bottle.startDate) ? .destructive : .disabled
+        }
+        
         return UIAction(title: title, attributes: attributes) { _ in
             self.openBottleItemDidTap(bottle)
         }


### PR DESCRIPTION
## 반영 내용
- #219 
- #207 

<br>

### 홈탭에 더보기 버튼 추가, 중도 개봉 기능 구현
- 중도 개봉 기능을 추가하면서 UI 일관성 및 유저 편의를 위해 저금통 이름 변경 기능과 개봉 기능을 오른쪽 위 더보기 버튼의 하위 항목으로 이동했습니다. 
  - 이름 라벨의 탭 제스처를 삭제했습니다. 
  - 디데이가 지난 후 홈뷰를 탭하는 경우 오른쪽 위의 더보기 버튼을 눌러 개봉해달라는 알림을 띄우도록 변경했습니다.  
- 더보기 버튼에 저금통과 관련한 기능만 들어있으므로 저금통이 있는 경우에만 더보기 버튼이 나타나고 없는 경우에는 버튼도 숨기도록 했습니다.  
- 유저 편의를 위해 더보기 버튼의 터치 인식 영역을 버튼 크기보다 크게 설정했습니다.
- HIG에 따라 더보기 버튼은 pull down button 으로 구현했습니다. 
  - 버튼을 누를 때마다 저금통의 상태를 확인해서 중도 개봉/일반 개봉 중 해당하는 항목을 나타내도록 했습니다. 
  - 중도 개봉의 경우 돌이킬 수 없으므로 destructive 옵션을 적용했습니다. (빨간 글씨 + 액션 시트)    
- 유저가 디바이스 시간을 저금통 생성일보다 과거로 돌리면 중도 개봉 버튼을 비활성화 했습니다.
  - 사실 활성화해도 리스트에 날짜가 이상하게 나오는 거 빼고는 꼬이는 거 없긴 한데 날짜 상 말이 안되니까 걍 막아버렸어용 
- 유저가 중도 개봉을 하는 경우 저금통 리스트탭의 개봉일에 오늘 날짜가 나타나도록 개봉 날짜를 변경하도록 했습니다. 

<br>

## 추후 작업
- 중도 개봉에 따른 **알림 초기화 부분 추가 부탁드립니당**!