### PR TITLE
[fix] 유저가 디바이스 시간을 과거로 돌리는 경우 발생하는 쪽지 작성 관련 버그 수정 #218

### DIFF
--- a/Happiggy-bank/Happiggy-bank.xcodeproj/project.pbxproj
+++ b/Happiggy-bank/Happiggy-bank.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		A439F53E27EEFCF6002851F4 /* SettingsToggleButtonCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = A439F53C27EEFCF6002851F4 /* SettingsToggleButtonCell.xib */; };
 		A439F54527EF0698002851F4 /* SettingsLabelButtonCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A439F54327EF0698002851F4 /* SettingsLabelButtonCell.swift */; };
 		A44E901727D5EB130053AC57 /* Happiggy-bank.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = A44E901527D5EB130053AC57 /* Happiggy-bank.xcdatamodeld */; };
+		A4534714285071A800F77164 /* Date+Tomorrow.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4534713285071A800F77164 /* Date+Tomorrow.swift */; };
 		A456657C27CC66FD007CF70A /* DefaultButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = A817430027C112D00016C921 /* DefaultButton.swift */; };
 		A456657E27CC77A9007CF70A /* Date+Formatted.swift in Sources */ = {isa = PBXBuildFile; fileRef = A456657D27CC77A9007CF70A /* Date+Formatted.swift */; };
 		A4569CB8280FB979001E3FD6 /* Presenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4569CB7280FB979001E3FD6 /* Presenter.swift */; };
@@ -164,6 +165,7 @@
 		A439F53C27EEFCF6002851F4 /* SettingsToggleButtonCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SettingsToggleButtonCell.xib; sourceTree = "<group>"; };
 		A439F54327EF0698002851F4 /* SettingsLabelButtonCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsLabelButtonCell.swift; sourceTree = "<group>"; };
 		A44E901627D5EB130053AC57 /* Happigy-bank.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Happigy-bank.xcdatamodel"; sourceTree = "<group>"; };
+		A4534713285071A800F77164 /* Date+Tomorrow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Tomorrow.swift"; sourceTree = "<group>"; };
 		A456657D27CC77A9007CF70A /* Date+Formatted.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Formatted.swift"; sourceTree = "<group>"; };
 		A4569CB7280FB979001E3FD6 /* Presenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Presenter.swift; sourceTree = "<group>"; };
 		A4569CB9280FBA23001E3FD6 /* CustomResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomResult.swift; sourceTree = "<group>"; };
@@ -522,6 +524,7 @@
 				A4D6EB7C2837901F00553E43 /* URL+AppStore.swift */,
 				A4D357DF283A43C7007819E3 /* UIViewController+VersionUpdating.swift */,
 				A4D357E1283A4429007819E3 /* URL+Open.swift */,
+				A4534713285071A800F77164 /* Date+Tomorrow.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -787,6 +790,7 @@
 				A4D6EB77282E307900553E43 /* VersionManager.swift in Sources */,
 				A89CBEDB27CBDD99005549F6 /* BottleCell.swift in Sources */,
 				A44E901727D5EB130053AC57 /* Happiggy-bank.xcdatamodeld in Sources */,
+				A4534714285071A800F77164 /* Date+Tomorrow.swift in Sources */,
 				A4C1AFD427E5E6120096CD3E /* UITextView+ParagraphStyle.swift in Sources */,
 				A46B10F228142F26004AB185 /* UIViewController+ObserveCustomFontChange.swift in Sources */,
 				A466A31A2802987700D655F4 /* UIAlertAction+ConfirmAndCancel.swift in Sources */,

--- a/Happiggy-bank/Happiggy-bank/CoreData/Bottle+CoreDataClass.swift
+++ b/Happiggy-bank/Happiggy-bank/CoreData/Bottle+CoreDataClass.swift
@@ -121,20 +121,28 @@ public class Bottle: NSManagedObject {
     
     /// 오늘이 저금통 시작일을 포함해서 며칠째인지
     var numberOfDaysSinceStartDate: Int {
-        Calendar.daysBetween(start: self.startDate, end: Date())
+        let days = Calendar.daysBetween(start: self.startDate, end: Date())
+        guard days > .zero
+        else { return .zero }
+        
+        return days
     }
     
     /// 현재까지의 날짜 중에서 쪽지를 쓰지 않은 날짜가 있는지 나타냄
     var hasEmptyDate: Bool {
-        self.numberOfDaysSinceStartDate > self.notes.count
+        guard self.numberOfDaysSinceStartDate != .zero
+        else { return false }
+        
+        return self.numberOfDaysSinceStartDate > self.notes.count
     }
     
     /// 오늘 쪽지를 썼는지 여부
     var isEmtpyToday: Bool {
-        guard let mostRecentNote = self.notes.last?.date
-        else { return true }
-
-        return !Calendar.current.isDateInToday(mostRecentNote)
+        guard Date() >= Calendar.current.startOfDay(for: self.startDate) 
+        else { return false }
+        
+        let noteToday = self.notes.reversed().first { Calendar.current.isDateInToday($0.date) }
+        return (noteToday == nil) ? true : false
     }
     
     /// 시작 날짜부터 끝 날짜까지의 텍스트 라벨

--- a/Happiggy-bank/Happiggy-bank/Extensions/Date+Tomorrow.swift
+++ b/Happiggy-bank/Happiggy-bank/Extensions/Date+Tomorrow.swift
@@ -1,0 +1,21 @@
+//
+//  Date+Tomorrow.swift
+//  Happiggy-bank
+//
+//  Created by sun on 2022/06/08.
+//
+
+import Foundation
+
+extension Date {
+    
+    /// 내일
+    static var tomorrow: Date {
+        Calendar.current.date(byAdding: .day, value: one, to: Date()) ?? Date()
+    }
+    
+    /// 내일 시작: xx시 00분
+    static var startOfTomorrow: Date { Calendar.current.startOfDay(for: self.tomorrow) }
+    
+    private static let one = 1
+}

--- a/Happiggy-bank/Happiggy-bank/ViewModel/NewNoteDatePickerViewModel.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewModel/NewNoteDatePickerViewModel.swift
@@ -31,6 +31,9 @@ final class NewNoteDatePickerViewModel {
         
         /// 쪽지들 확인하면서 맞는 날짜에 색깔 기록
         for note in self.bottle.notes {
+            guard note.date < Date.startOfTomorrow
+            else { continue }
+            
             let index = Calendar.daysBetween(start: startDate, end: note.date) - 1
             source[index].color = note.color
         }


### PR DESCRIPTION
## 작업 내용
- resolves #218 

디바이스 시간을 과거로 돌리는 경우 은빈님이 이전에 제보해주셨던 문제를 비롯해 다음과 같은 사항을 처리했습니다. 
원인은 다 시간여행자를 고려하지 않았다는 것...ㅎ그흑 

- 시간을 과거로 돌리는 경우 돌린 날짜에 이미 쪽지를 작성했어도 다시 쪽지 작성이 가능한 현상
  - 기존에는 홈탭에서 화면을 탭하면 과거로 시간을 돌릴 수 있다는 점을 고려하지 않고 항상 가장 최근 날짜에 작성한 쪽지를 가지고 오늘 날짜에 해당하는 지를 확인하는 방식이었는데, 이로 인해 2일에 쪽지를 작성하고 나서 1일로 시간을 돌리면 가장 최근 날짜인 2일의 쪽지를 가지고 1일에 작성했는지 아닌지를 확인하기 때문에 또 다시 작성이 가능해지는 것이었습니다... .
  - 따라서 그냥 전체 쪽지 배열을 다 돌면서 디바이스 기준 현재 날짜와 비교해서 해당 날짜의 쪽지가 있는지에 따라 작성 뷰를 띄우는 방식으로 변경했습니다. 

<br>

- 시간을 과거로 돌린 후 백그라운드 -> 포어그라운드로 오는 경우 크래시가 나는 현상
  - 마찬가지로 시간을 달릴 수 있다고 생각을 안해서 행 개수는 시작일~오늘까지만큼 날짜 수로 하고, 쪽지는 전체를 다 가져와서 작성 여부를 확인하고 피커에 나타냈는데,  이런 경우 시간을 과거로 돌리면 해당 시점 기준 미래의 쪽지는 존재는 하는데 행에는 나타낼 자리가 없어 인덱스 에러가 발생하면서 크래시가 났습니다. 
  - 따라서 쪽지 배열 전체를 돌 때 항상 디바이스의 현재 시점을 기준으로 현재까지의 쪽지만을 나타내도록 했습니다. 

<br>

- 시간을 저금통 생성일 이전으로 돌린 경우 대응 필요
  - 위의 문제들을 보고 나니까 시간을 아예 저금통 생성일 이전으로 돌리는 경우도 대응해줘야할 것 같아서 걍 저금통 자체는 띄우고(중복 생성 안되게) 작성창은 안 뜨게 막아뒀습니다


홈뷰에 쪽지 노드들은 과거로 돌리든 말든 걍 지금까지 작성한 거 다 뜨게 뒀습니당...이건 크래시도 안나고 굳이 싶어서...ㅋㅋㅋㅋㅋ
