### PR TITLE
[feat] note cell에 새로운 색상 반영

### DIFF
--- a/Happiggy-bank/Happiggy-bank/Subview/NoteCell.swift
+++ b/Happiggy-bank/Happiggy-bank/Subview/NoteCell.swift
@@ -92,11 +92,9 @@ final class NoteCell: UITableViewCell {
     /// 셀을 내용을 채우는 메서드
     private func render() {
         self.validView.backgroundColor = self.viewModel?.basicColor
-        self.backgroundImageView.tintColor = self.viewModel?.tintColor
+        self.backgroundImageView.tintColor = self.viewModel?.borderColor
         self.dateLabel.attributedText = self.viewModel?.attributedDateString
-        self.dateLabel.configureParagraphStyle()
         self.indexLabel.attributedText = self.viewModel?.attributedIndexString
-        self.indexLabel.configureParagraphStyle()
         self.contentLabel.attributedText = self.viewModel?.attributedContentString
         self.contentLabel.configureParagraphStyle(font: .systemFont(ofSize: FontSize.body))
     }

--- a/Happiggy-bank/Happiggy-bank/Subview/PhotoNoteCell.swift
+++ b/Happiggy-bank/Happiggy-bank/Subview/PhotoNoteCell.swift
@@ -102,11 +102,9 @@ final class PhotoNoteCell: UITableViewCell {
     /// 셀을 내용을 채우는 메서드
     private func render() {
         self.validView.backgroundColor = self.viewModel?.basicColor
-        self.backgroundImageView.tintColor = self.viewModel?.tintColor
+        self.backgroundImageView.tintColor = self.viewModel?.borderColor
         self.dateLabel.attributedText = self.viewModel?.attributedDateString
-        self.dateLabel.configureParagraphStyle()
         self.indexLabel.attributedText = self.viewModel?.attributedIndexString
-        self.indexLabel.configureParagraphStyle()
         self.contentLabel.attributedText = self.viewModel?.attributedContentString
         self.contentLabel.configureParagraphStyle(font: .systemFont(ofSize: FontSize.body))
         self.photoView.image = self.viewModel?.photo()

--- a/Happiggy-bank/Happiggy-bank/ViewModel/PhotoNoteCellViewModel.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewModel/PhotoNoteCellViewModel.swift
@@ -22,12 +22,18 @@ final class PhotoNoteCellViewModel {
 
     /// 색상, 부분 강조 표시를 적용한 날짜 문자열
     private(set) lazy var attributedDateString: NSMutableAttributedString = {
-        var date = String.empty.nsMutableAttributedStringify()
+        let date = String.empty.nsMutableAttributedStringify()
         let year = note.date.yearString
             .nsMutableAttributedStringify()
             .bold(fontSize: FontSize.secondaryLabel)
         let spacedMonthAndDay = " \(note.date.monthDotDayWithDayOfWeekString)"
             .nsMutableAttributedStringify()
+        let range = spacedMonthAndDay.mutableString.range(of: spacedMonthAndDay.string)
+        spacedMonthAndDay.addAttribute(
+            .font,
+            value: UIFont.systemFont(ofSize: FontSize.secondaryLabel),
+            range: range
+        )
 
         date.append(year)
         date.append(spacedMonthAndDay)
@@ -38,16 +44,22 @@ final class PhotoNoteCellViewModel {
 
     /// 색상, 부분 강조 표시를 적용한 인덱스 문자열
     private(set) lazy var attributedIndexString: NSMutableAttributedString = {
-        var result = String.empty.nsMutableAttributedStringify()
-        let index = self.index.description.nsMutableAttributedStringify()
-            .color(color: self.tintColor)
+        let index = self.index.description
+            .nsMutableAttributedStringify()
             .bold(fontSize: FontSize.secondaryLabel)
-        let total = "/\(self.numberOfTotalNotes.description)".nsMutableAttributedStringify()
+        let total = "\(StringLiteral.slash)\(self.numberOfTotalNotes)"
+            .nsMutableAttributedStringify()
+        let range = total.mutableString.range(of: total.string)
+        total.addAttribute(
+            .font,
+            value: UIFont.systemFont(ofSize: FontSize.secondaryLabel),
+            range: range
+        )
 
-        result.append(index)
-        result.append(total)
+        index.append(total)
+        index.color(color: self.tintColor)
 
-        return result
+        return index
     }()
 
     /// 유저가 작성한 내용
@@ -58,8 +70,11 @@ final class PhotoNoteCellViewModel {
     /// 기본 색상
     private(set) lazy var basicColor: UIColor = { .note(color: self.note.color) }()
 
+    /// 테두리 색상
+    private(set) lazy var borderColor: UIColor = { .noteBorder(for: self.note.color) }()
+
     /// 강조 색상
-    private(set) lazy var tintColor: UIColor = { .noteHighlight(for: self.note.color) }()
+    private lazy var tintColor: UIColor = { .noteHighlight(for: self.note.color) }()
 
     /// 쪽지 객체
     private let note: Note
@@ -93,5 +108,14 @@ final class PhotoNoteCellViewModel {
         }
 
         return self.imageManager.image(forNote: note.id, imageURL: url) ?? .error
+    }
+}
+
+
+// MARK: - Constants
+fileprivate extension PhotoNoteCellViewModel {
+
+    enum StringLiteral {
+        static let slash = "/"
     }
 }


### PR DESCRIPTION
### 변경사항
- 쪽지 목록의 note cell, photo note cell에 새로운 색상이 변경되지 않아 반영했습니다. 
  - 테두리 선 색상이 연해졌고 
  - 몇 번째 쪽지인지 나타내는 레이블 색상이 변경되었습니다.

### 스크린샷 
|전|후|
|---|---|
|<img src="https://user-images.githubusercontent.com/81314063/205196939-054f25ca-774f-4bfb-aef6-614d0c26ca6e.png" width=300>|<img src="https://user-images.githubusercontent.com/81314063/205197249-9a7a2fca-0ed7-4677-ae98-9545b865fc44.jpeg" width=300>|
