### PR TITLE
[chore] 앱 진입 화면을 Main 스토리보드에서 CustomTabBarController로 수정 #249

### DIFF
--- a/Happiggy-bank/Happiggy-bank.xcodeproj/project.pbxproj
+++ b/Happiggy-bank/Happiggy-bank.xcodeproj/project.pbxproj
@@ -1013,7 +1013,6 @@
 				INFOPLIST_KEY_CFBundleDisplayName = "행복저금통";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
-				INFOPLIST_KEY_UIMainStoryboardFile = Main;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
@@ -1045,7 +1044,6 @@
 				INFOPLIST_KEY_CFBundleDisplayName = "행복저금통";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
-				INFOPLIST_KEY_UIMainStoryboardFile = Main;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;

--- a/Happiggy-bank/Happiggy-bank/Info.plist
+++ b/Happiggy-bank/Happiggy-bank/Info.plist
@@ -28,8 +28,6 @@
 					<string>Default Configuration</string>
 					<key>UISceneDelegateClassName</key>
 					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
-					<key>UISceneStoryboardFile</key>
-					<string>Main</string>
 				</dict>
 			</array>
 		</dict>

--- a/Happiggy-bank/Happiggy-bank/SceneDelegate.swift
+++ b/Happiggy-bank/Happiggy-bank/SceneDelegate.swift
@@ -23,6 +23,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let scene = (scene as? UIWindowScene)
         else { return }
         
+        window = UIWindow(frame: scene.coordinateSpace.bounds)
+        window?.windowScene = scene
+        window?.rootViewController = CustomTabBarController()
+        window?.makeKeyAndVisible()
+        
         guard let errorMessage = PersistenceStore.fatalErrorDescription
         else {
             /// 정상적인 경우

--- a/Happiggy-bank/Happiggy-bank/ViewController/CustomTabBarController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/CustomTabBarController.swift
@@ -11,7 +11,7 @@ import UIKit
 final class CustomTabBarController: UITabBarController {
     
     // MARK: - Life cycle
-
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -39,6 +39,8 @@ final class CustomTabBarController: UITabBarController {
         else { return }
         
         self.changeTabBarFont(to: font)
+        self.setColors()
+        self.setNavigationControllers()
     }
     
     /// 내비게이션 바 아이템 폰트 변경
@@ -51,5 +53,73 @@ final class CustomTabBarController: UITabBarController {
             $0.setTitleTextAttributes(attributes, for: .normal)
             $0.setTitleTextAttributes(attributes, for: .selected)
         }
+    }
+    
+    /// 탭 바 컨트롤러 기본 색상 설정
+    private func setColors() {
+        self.view.backgroundColor = .systemBackground
+        self.tabBar.barTintColor = .tabBarDivider
+        self.tabBar.tintColor = .customTint
+    }
+    
+    
+    // TODO: - 각 NavigationController에 들어갈 ViewController 수정/교체
+    /// 탭 바의 내비게이션 컨트롤러 배열 설정
+    private func setNavigationControllers() {
+        self.viewControllers = [
+            createNavigationController(
+                for: UIViewController(),
+                title: StringLiteral.home,
+                image: UIImage.homeIconNormal,
+                selectedImage: UIImage.homeIconSelected
+            ),
+            createNavigationController(
+                for: UIViewController(),
+                title: StringLiteral.bottleList,
+                image: UIImage.listIconNormal,
+                selectedImage: UIImage.listIconSelected
+            ),
+            createNavigationController(
+                for: UIViewController(),
+                title: StringLiteral.settings,
+                image: UIImage.settingsIconNormal,
+                selectedImage: UIImage.settingsIconSelected
+            )
+        ]
+    }
+    
+    /// 각 내비게이션 컨트롤러 기본 설정
+    fileprivate func createNavigationController(
+        for rootViewController: UIViewController,
+        title: String,
+        image: UIImage?,
+        selectedImage: UIImage?
+    ) -> UIViewController {
+        
+        let navigationController = UINavigationController(rootViewController: rootViewController)
+        
+        navigationController.tabBarItem.title = title
+        navigationController.tabBarItem.image = image
+        navigationController.tabBarItem.selectedImage = selectedImage
+        navigationController.navigationBar.isHidden = true
+        
+        return navigationController
+    }
+}
+
+
+extension CustomTabBarController {
+    
+    /// 탭 바 컨트롤러에서 사용하는 문자열
+    enum StringLiteral {
+        
+        /// 홈 화면 탭 바 아이템 타이틀
+        static let home: String = "홈"
+        
+        /// 저금통 목록 화면 탭 바 아이템 타이틀
+        static let bottleList: String = "저금통 목록"
+        
+        /// 환경설정 화면 탭 바 아이템 타이틀
+        static let settings: String = "환경설정"
     }
 }

--- a/Happiggy-bank/Happiggy-bank/ViewController/CustomTabBarController.swift
+++ b/Happiggy-bank/Happiggy-bank/ViewController/CustomTabBarController.swift
@@ -69,21 +69,21 @@ final class CustomTabBarController: UITabBarController {
         self.viewControllers = [
             createNavigationController(
                 for: UIViewController(),
-                title: StringLiteral.home,
-                image: UIImage.homeIconNormal,
-                selectedImage: UIImage.homeIconSelected
+                title: Tab.home.title,
+                image: Tab.home.image,
+                selectedImage: Tab.home.selectedImage
             ),
             createNavigationController(
                 for: UIViewController(),
-                title: StringLiteral.bottleList,
-                image: UIImage.listIconNormal,
-                selectedImage: UIImage.listIconSelected
+                title: Tab.bottleList.title,
+                image: Tab.bottleList.image,
+                selectedImage: Tab.bottleList.selectedImage
             ),
             createNavigationController(
                 for: UIViewController(),
-                title: StringLiteral.settings,
-                image: UIImage.settingsIconNormal,
-                selectedImage: UIImage.settingsIconSelected
+                title: Tab.settings.title,
+                image: Tab.settings.image,
+                selectedImage: Tab.settings.selectedImage
             )
         ]
     }
@@ -110,16 +110,45 @@ final class CustomTabBarController: UITabBarController {
 
 extension CustomTabBarController {
     
-    /// 탭 바 컨트롤러에서 사용하는 문자열
-    enum StringLiteral {
+    enum Tab: Int {
+        case home
+        case bottleList
+        case settings
         
-        /// 홈 화면 탭 바 아이템 타이틀
-        static let home: String = "홈"
+        /// 탭 바 아이템 타이틀
+        var title: String {
+            switch self {
+            case .home:
+                return "홈"
+            case .bottleList:
+                return "저금통 목록"
+            case .settings:
+                return "환경설정"
+            }
+        }
         
-        /// 저금통 목록 화면 탭 바 아이템 타이틀
-        static let bottleList: String = "저금통 목록"
+        /// 탭 바 아이템 이미지
+        var image: UIImage? {
+            switch self {
+            case .home:
+                return UIImage.homeIconNormal
+            case .bottleList:
+                return UIImage.listIconNormal
+            case .settings:
+                return UIImage.settingsIconNormal
+            }
+        }
         
-        /// 환경설정 화면 탭 바 아이템 타이틀
-        static let settings: String = "환경설정"
+        /// 탭 바 아이템 선택됐을 때 이미지
+        var selectedImage: UIImage? {
+            switch self {
+            case .home:
+                return UIImage.homeIconSelected
+            case .bottleList:
+                return UIImage.listIconSelected
+            case .settings:
+                return UIImage.settingsIconSelected
+            }
+        }
     }
 }


### PR DESCRIPTION
- [x] SceneDelegate 수정
  - CustomTabBarController로 진입할 수 있도록 코드 추가
- [x] info.plist 수정
  - Main.storyboard key-value 값 삭제
- [x] CustomTabBarController 수정
  - 기본 색상 설정
  - 각 탭의 내비게이션 컨트롤러 생성 **=> 추후 리팩토링 거치면서 각 화면에 맞는 컨트롤러로 변경 필요**
  - [x] TabBarItem에 대한 title StringLiteral이 없어서 extension으로 뺐는데 Constants나 다른 파일에 중복되는 거 있으면 말해주세요.
  - [x] TabBarItem에 대한 image, selectedImage가 모두 UIImage에 정의되어있는 것 같아서 그거로 갖다 썼는데 이렇게 쓰는거 아니면 말해주세요!