### PR TITLE
[feat] 네트워크 매니저 구현 #265

### DIFF
--- a/Happiggy-bank/Happiggy-bank.xcodeproj/project.pbxproj
+++ b/Happiggy-bank/Happiggy-bank.xcodeproj/project.pbxproj
@@ -70,6 +70,11 @@
 		A484A3052958945E00A58312 /* BaseTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A484A3042958945E00A58312 /* BaseTextView.swift */; };
 		A484A3072958949700A58312 /* BaseTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = A484A3062958949700A58312 /* BaseTextField.swift */; };
 		A484A3092958953600A58312 /* BaseButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = A484A3082958953600A58312 /* BaseButton.swift */; };
+		A484A317295D619A00A58312 /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A484A316295D619A00A58312 /* NetworkManager.swift */; };
+		A484A31A295D756D00A58312 /* NetworkServiceable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A484A319295D756D00A58312 /* NetworkServiceable.swift */; };
+		A484A31C295D75F900A58312 /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A484A31B295D75F900A58312 /* NetworkError.swift */; };
+		A484A31E295D7B1400A58312 /* HTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = A484A31D295D7B1400A58312 /* HTTPMethod.swift */; };
+		A484A320295D7B2A00A58312 /* Requestable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A484A31F295D7B2A00A58312 /* Requestable.swift */; };
 		A48E183A27E71D9300B44477 /* UILabel+ParagraphStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = A48E183927E71D9300B44477 /* UILabel+ParagraphStyle.swift */; };
 		A48E183C27E7379100B44477 /* CapsuleButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = A48E183B27E7379100B44477 /* CapsuleButton.swift */; };
 		A48E183E27E737B600B44477 /* CapsuleButton.xib in Resources */ = {isa = PBXBuildFile; fileRef = A48E183D27E737B600B44477 /* CapsuleButton.xib */; };
@@ -230,6 +235,11 @@
 		A484A3042958945E00A58312 /* BaseTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseTextView.swift; sourceTree = "<group>"; };
 		A484A3062958949700A58312 /* BaseTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseTextField.swift; sourceTree = "<group>"; };
 		A484A3082958953600A58312 /* BaseButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseButton.swift; sourceTree = "<group>"; };
+		A484A316295D619A00A58312 /* NetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManager.swift; sourceTree = "<group>"; };
+		A484A319295D756D00A58312 /* NetworkServiceable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkServiceable.swift; sourceTree = "<group>"; };
+		A484A31B295D75F900A58312 /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
+		A484A31D295D7B1400A58312 /* HTTPMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPMethod.swift; sourceTree = "<group>"; };
+		A484A31F295D7B2A00A58312 /* Requestable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Requestable.swift; sourceTree = "<group>"; };
 		A48E183927E71D9300B44477 /* UILabel+ParagraphStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+ParagraphStyle.swift"; sourceTree = "<group>"; };
 		A48E183B27E7379100B44477 /* CapsuleButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CapsuleButton.swift; sourceTree = "<group>"; };
 		A48E183D27E737B600B44477 /* CapsuleButton.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CapsuleButton.xib; sourceTree = "<group>"; };
@@ -342,6 +352,18 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		A484A318295D664B00A58312 /* Network */ = {
+			isa = PBXGroup;
+			children = (
+				A484A319295D756D00A58312 /* NetworkServiceable.swift */,
+				A484A316295D619A00A58312 /* NetworkManager.swift */,
+				A484A31B295D75F900A58312 /* NetworkError.swift */,
+				A484A31D295D7B1400A58312 /* HTTPMethod.swift */,
+				A484A31F295D7B2A00A58312 /* Requestable.swift */,
+			);
+			path = Network;
+			sourceTree = "<group>";
+		};
 		A491016F27D605C40012DFDD /* CoreData */ = {
 			isa = PBXGroup;
 			children = (
@@ -501,6 +523,7 @@
 				A49A8C202952F54900D5468A /* DebugPrint.swift */,
 				A49A8C2229530FDF00D5468A /* AssetColor.swift */,
 				A49A8C24295331B000D5468A /* AssetImage.swift */,
+				A484A318295D664B00A58312 /* Network */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -780,6 +803,7 @@
 				A4D357E0283A43C7007819E3 /* UIViewController+VersionUpdating.swift in Sources */,
 				A8BD834727BE337900E0DE41 /* HomeView.swift in Sources */,
 				A46B10FC28144D76004AB185 /* CustomTabBarController.swift in Sources */,
+				A484A31A295D756D00A58312 /* NetworkServiceable.swift in Sources */,
 				A484A3072958949700A58312 /* BaseTextField.swift in Sources */,
 				A4CF2C7C27C71FF5001B01B1 /* CATransition+PopupAnimation.swift in Sources */,
 				A49B25F42812FFB400399630 /* UILabel+BoldAndColor.swift in Sources */,
@@ -797,11 +821,13 @@
 				A4396B1B29325D70005D9D3A /* PhotoViewController.swift in Sources */,
 				A8ECD4A727E33BFA00886BC0 /* BottleListViewModel.swift in Sources */,
 				A49AC5EB2917FFAB009315BC /* PhotoNoteCellViewModel.swift in Sources */,
+				A484A317295D619A00A58312 /* NetworkManager.swift in Sources */,
 				A49A8C212952F54900D5468A /* DebugPrint.swift in Sources */,
 				A4A55A0728FFC664004ABE00 /* UIView+ConfigureXib.swift in Sources */,
 				A843332427DA397800A12A54 /* DataProvider.swift in Sources */,
 				A48E183A27E71D9300B44477 /* UILabel+ParagraphStyle.swift in Sources */,
 				A4B2860B27D9B434008769EB /* UIViewController+FadeOut.swift in Sources */,
+				A484A31C295D75F900A58312 /* NetworkError.swift in Sources */,
 				D22ADF7F27F72F7300ECB77B /* NotificationSettingsViewModel.swift in Sources */,
 				A49AC5E52917C6E2009315BC /* UILabel+ChangeFontSize.swift in Sources */,
 				D22ADF7F27F72F7300ECB77B /* NotificationSettingsViewModel.swift in Sources */,
@@ -835,11 +861,13 @@
 				A4D6EB7B2837825500553E43 /* LookUpResult.swift in Sources */,
 				A439F54527EF0698002851F4 /* SettingsLabelButtonCell.swift in Sources */,
 				A484A3032958936300A58312 /* BaseLabel.swift in Sources */,
+				A484A320295D7B2A00A58312 /* Requestable.swift in Sources */,
 				A41A506F27FF2B2E005381EF /* CustomTabBar.swift in Sources */,
 				A490AC5027DD9D2E00B04CE1 /* NoteListViewModel.swift in Sources */,
 				A4569CB8280FB979001E3FD6 /* Presenter.swift in Sources */,
 				A466A3182801E99500D655F4 /* SettingsViewModel.swift in Sources */,
 				A4F5714927DA589100E7DF9B /* NoteDatePickerData.swift in Sources */,
+				A484A31E295D7B1400A58312 /* HTTPMethod.swift in Sources */,
 				D2C48BFF27E9D60A006FC59E /* Gravity.swift in Sources */,
 				A8EB5E8B27C8B087005704F2 /* UIButton+Extension.swift in Sources */,
 				A4D357DE283A3E01007819E3 /* VersionUpdating.swift in Sources */,

--- a/Happiggy-bank/Happiggy-bank/Utils/Network/HTTPMethod.swift
+++ b/Happiggy-bank/Happiggy-bank/Utils/Network/HTTPMethod.swift
@@ -1,0 +1,12 @@
+//
+//  HTTPMethod.swift
+//  Happiggy-bank
+//
+//  Created by sun on 2022/12/29.
+//
+
+import Foundation
+
+enum HTTPMethod: String {
+    case GET
+}

--- a/Happiggy-bank/Happiggy-bank/Utils/Network/NetworkError.swift
+++ b/Happiggy-bank/Happiggy-bank/Utils/Network/NetworkError.swift
@@ -19,14 +19,14 @@ enum NetworkError: LocalizedError {
     var errorDescription: String? {
         switch self {
         case .invalidRequest:
-            return NSLocalizedString("잘못된 요청입니다.", comment: "invalid request")
+            return "잘못된 요청입니다."
         case .transportError:
-            return NSLocalizedString("통신 에러가 발생했습니다", comment: "transport error")
+            return "통신 에러가 발생했습니다"
         case .serverSideError(let statusCode):
             let statusCodeIfNeeded = statusCode != nil ? " 상태코드: \(statusCode!)" : .empty
-            return NSLocalizedString("서버에 에러가 발생했습니다.\(statusCodeIfNeeded)", comment: "server-side error")
+            return "서버에 에러가 발생했습니다.\(statusCodeIfNeeded)"
         case .decodingFailure:
-            return NSLocalizedString("디코딩에 실패했습니다.", comment: "decoding failure")
+            return "디코딩에 실패했습니다."
         }
     }
 }

--- a/Happiggy-bank/Happiggy-bank/Utils/Network/NetworkError.swift
+++ b/Happiggy-bank/Happiggy-bank/Utils/Network/NetworkError.swift
@@ -1,0 +1,32 @@
+//
+//  NetworkError.swift
+//  Happiggy-bank
+//
+//  Created by sun on 2022/12/29.
+//
+
+import Foundation
+
+enum NetworkError: LocalizedError {
+    case invalidRequest
+    case transportError
+    case serverSideError(statusCode: Int?)
+    case decodingFailure
+
+
+    // MARK: - Properties
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidRequest:
+            return NSLocalizedString("잘못된 요청입니다.", comment: "invalid request")
+        case .transportError:
+            return NSLocalizedString("통신 에러가 발생했습니다", comment: "transport error")
+        case .serverSideError(let statusCode):
+            let statusCodeIfNeeded = statusCode != nil ? " 상태코드: \(statusCode!)" : .empty
+            return NSLocalizedString("서버에 에러가 발생했습니다.\(statusCodeIfNeeded)", comment: "server-side error")
+        case .decodingFailure:
+            return NSLocalizedString("디코딩에 실패했습니다.", comment: "decoding failure")
+        }
+    }
+}

--- a/Happiggy-bank/Happiggy-bank/Utils/Network/NetworkManager.swift
+++ b/Happiggy-bank/Happiggy-bank/Utils/Network/NetworkManager.swift
@@ -17,7 +17,7 @@ struct NetworkManager: NetworkServiceable {
 
     // MARK: - Functions
 
-    func fetchDecodedData<T: Decodable>(for endpoint: Requestable) async throws -> T {
+    func resume<T: Decodable>(for endpoint: Requestable) async throws -> T {
         let request = try self.makeRequest(for: endpoint)
         let data = try await self.fetchData(for: request)
 

--- a/Happiggy-bank/Happiggy-bank/Utils/Network/NetworkManager.swift
+++ b/Happiggy-bank/Happiggy-bank/Utils/Network/NetworkManager.swift
@@ -1,0 +1,72 @@
+//
+//  NetworkManager.swift
+//  Happiggy-bank
+//
+//  Created by sun on 2022/12/29.
+//
+
+import Foundation
+
+/// 네트워크 통신 객체
+struct NetworkManager: NetworkServiceable {
+
+    // MARK: - Properties
+
+    private let session = URLSession.shared
+
+
+    // MARK: - Functions
+
+    func fetchDecodedData<T: Decodable>(for endpoint: Requestable) async throws -> T {
+        let request = try self.makeRequest(for: endpoint)
+        let data = try await self.fetchData(for: request)
+
+        return try self.decodeData(data)
+    }
+
+    private func makeRequest(for endpoint: Requestable) throws -> URLRequest {
+        guard let url = URL(string: endpoint.urlString)
+        else {
+            throw NetworkError.invalidRequest
+        }
+
+        var request = URLRequest(url: url)
+        request.allHTTPHeaderFields = endpoint.headers
+        request.httpMethod = endpoint.httpMethod.rawValue
+        request.httpBody = endpoint.httpBody
+
+        return request
+    }
+
+    private func fetchData(for request: URLRequest) async throws -> Data {
+        do {
+            let (data, response) = try await session.data(for: request)
+            let statusCode = (response as? HTTPURLResponse)?.statusCode
+            guard let statusCode,
+                  Metric.validStatusCodeRange ~= statusCode
+            else {
+                throw NetworkError.serverSideError(statusCode: statusCode)
+            }
+            return data
+        } catch {
+            throw NetworkError.transportError
+        }
+    }
+
+    private func decodeData<T: Decodable>(_ data: Data) throws -> T {
+        do {
+            return try JSONDecoder().decode(T.self, from: data)
+        } catch {
+            throw NetworkError.decodingFailure
+        }
+    }
+}
+
+
+// MARK: - Constants
+fileprivate extension NetworkManager {
+
+    enum Metric {
+        static let validStatusCodeRange = 200..<300
+    }
+}

--- a/Happiggy-bank/Happiggy-bank/Utils/Network/NetworkServiceable.swift
+++ b/Happiggy-bank/Happiggy-bank/Utils/Network/NetworkServiceable.swift
@@ -13,5 +13,5 @@ protocol NetworkServiceable {
     /// 주어진 endpoint에서 데이터를 받아와 Decodable한 T 타입으로 리턴하며 실패시 NetworkError를 던짐
     /// - Parameter endpoint: 데이터를 받아올 엔드포인트로 Requestable 프로토콜을 채택
     /// - Returns: T
-    func fetchDecodedData<T: Decodable>(for endpoint: Requestable) async throws -> T
+    func resume<T: Decodable>(for endpoint: Requestable) async throws -> T
 }

--- a/Happiggy-bank/Happiggy-bank/Utils/Network/NetworkServiceable.swift
+++ b/Happiggy-bank/Happiggy-bank/Utils/Network/NetworkServiceable.swift
@@ -1,0 +1,17 @@
+//
+//  NetworkServiceable.swift
+//  Happiggy-bank
+//
+//  Created by sun on 2022/12/29.
+//
+
+import Foundation
+
+/// 네트워크 통신 기능을 나타내는 타입
+protocol NetworkServiceable {
+
+    /// 주어진 endpoint에서 데이터를 받아와 Decodable한 T 타입으로 리턴하며 실패시 NetworkError를 던짐
+    /// - Parameter endpoint: 데이터를 받아올 엔드포인트로 Requestable 프로토콜을 채택
+    /// - Returns: T
+    func fetchDecodedData<T: Decodable>(for endpoint: Requestable) async throws -> T
+}

--- a/Happiggy-bank/Happiggy-bank/Utils/Network/Requestable.swift
+++ b/Happiggy-bank/Happiggy-bank/Utils/Network/Requestable.swift
@@ -1,0 +1,16 @@
+//
+//  Requestable.swift
+//  Happiggy-bank
+//
+//  Created by sun on 2022/12/29.
+//
+
+import Foundation
+
+/// HTTP 요청을 생성할 수 있는 타입
+protocol Requestable {
+    var urlString: String { get }
+    var httpMethod: HTTPMethod { get }
+    var headers: [String: String]? { get }
+    var httpBody: Data? { get }
+}


### PR DESCRIPTION
## 작업 내용 
- resolves #265 
- 네트워크 통신을 위한 네트워크 매니저를 구현했습니다. 
  - 버전 매니저 구현 시 통신 관련 기능을 분리하기 위해서 별도의 객체로 나눴습니다. 
- 보내려는 HTTP 리퀘스트를 Requstable 프로토콜을 채택한 타입으로 구현해서 네트워크 매니저의 `func fetchDecodedData<T: Decodable>(for endpoint: Requestable)` 메서드의 인자로 넘기면 데이터를 T 타입으로 디코딩해서 리턴하는 방식입니다!