### PR TITLE
[fix] 탭바 설정 누락되는 문제 해결

### DIFF
--- a/Happiggy-bank/Happiggy-bank/Base/UI/Controller/CustomTabBarController.swift
+++ b/Happiggy-bank/Happiggy-bank/Base/UI/Controller/CustomTabBarController.swift
@@ -52,13 +52,8 @@ final class CustomTabBarController: UITabBarController {
     
     /// 탭 바 초기 설정
     private func configureTabBar() {
-        let key = UserDefaults.Key.font.rawValue
-        guard let rawValue = UserDefaults.standard.value(forKey: key) as? Int,
-              let font = CustomFont(rawValue: rawValue)
-        else { return }
-        
         self.configureBasicSettings()
-        self.changeTabBarFont(to: font)
+        self.changeTabBarFont(to: CustomFont.current)
         self.setNavigationControllers()
     }
     


### PR DESCRIPTION
## 작업 내용
- 최초 앱 사용 시 UserDefaults에 저장된 CustomFont 값이 없어 탭바가 제대로 초기화되지 않는 버그를 수정했습니다. 
