### PR TITLE
[feat] 새 저금통 생성 화면, 컨트롤러 코드 생성

### DIFF
--- a/Happiggy-bank/Happiggy-bank.xcodeproj/project.pbxproj
+++ b/Happiggy-bank/Happiggy-bank.xcodeproj/project.pbxproj
@@ -149,6 +149,8 @@
 		A819CF9F27DDD97C00DE8E72 /* HapticManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A819CF9E27DDD97C00DE8E72 /* HapticManager.swift */; };
 		A819CFA127DE034F00DE8E72 /* NewBottle.swift in Sources */ = {isa = PBXBuildFile; fileRef = A819CFA027DE034F00DE8E72 /* NewBottle.swift */; };
 		A824A0B027CE72C000B99E9A /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = A824A0AF27CE72C000B99E9A /* Then */; };
+		A83CA2AF2993587300081E07 /* NewBottleMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83CA2AE2993587300081E07 /* NewBottleMessageView.swift */; };
+		A83CA2B1299359DB00081E07 /* NewBottleMessageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83CA2B0299359DB00081E07 /* NewBottleMessageViewController.swift */; };
 		A843331F27DA013800A12A54 /* NewBottleNameFieldViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A843331E27DA013800A12A54 /* NewBottleNameFieldViewController.swift */; };
 		A843332127DA026D00A12A54 /* NewBottleDatePickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A843332027DA026D00A12A54 /* NewBottleDatePickerViewController.swift */; };
 		A843332427DA397800A12A54 /* DataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A843332327DA397800A12A54 /* DataProvider.swift */; };
@@ -325,6 +327,8 @@
 		A81742FE27C108DC0016C921 /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
 		A819CF9E27DDD97C00DE8E72 /* HapticManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HapticManager.swift; sourceTree = "<group>"; };
 		A819CFA027DE034F00DE8E72 /* NewBottle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewBottle.swift; sourceTree = "<group>"; };
+		A83CA2AE2993587300081E07 /* NewBottleMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewBottleMessageView.swift; sourceTree = "<group>"; };
+		A83CA2B0299359DB00081E07 /* NewBottleMessageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewBottleMessageViewController.swift; sourceTree = "<group>"; };
 		A843331E27DA013800A12A54 /* NewBottleNameFieldViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewBottleNameFieldViewController.swift; sourceTree = "<group>"; };
 		A843332027DA026D00A12A54 /* NewBottleDatePickerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewBottleDatePickerViewController.swift; sourceTree = "<group>"; };
 		A843332327DA397800A12A54 /* DataProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataProvider.swift; sourceTree = "<group>"; };
@@ -570,6 +574,7 @@
 			children = (
 				A85B38852990CE7700ED8C72 /* NewBottleNameView.swift */,
 				A8D58DAF299286A700FD52A1 /* NewBottleDateView.swift */,
+				A83CA2AE2993587300081E07 /* NewBottleMessageView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -853,6 +858,7 @@
 				A843332027DA026D00A12A54 /* NewBottleDatePickerViewController.swift */,
 				D236DB8727FDD66900D7B8F0 /* NewBottleMessageFieldViewController.swift */,
 				A8D58DB129928AA900FD52A1 /* NewBottleDateViewController.swift */,
+				A83CA2B0299359DB00081E07 /* NewBottleMessageViewController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -1393,12 +1399,14 @@
 				A47D834A296716BF0028AA1D /* FontCell.swift in Sources */,
 				A8BD834727BE337900E0DE41 /* HomeView.swift in Sources */,
 				A46B10FC28144D76004AB185 /* CustomTabBarController.swift in Sources */,
+				A83CA2AF2993587300081E07 /* NewBottleMessageView.swift in Sources */,
 				A484A31A295D756D00A58312 /* NetworkServiceable.swift in Sources */,
 				A484A33129608C8700A58312 /* SettingsTableViewCell.swift in Sources */,
 				A47D83612973C3990028AA1D /* FontManaging.swift in Sources */,
 				A484A3072958949700A58312 /* BaseTextField.swift in Sources */,
 				A4CF2C7C27C71FF5001B01B1 /* CATransition+PopupAnimation.swift in Sources */,
 				A49B25F42812FFB400399630 /* UILabel+Color.swift in Sources */,
+				A83CA2B1299359DB00081E07 /* NewBottleMessageViewController.swift in Sources */,
 				A8FC07C827B3ECF00077A758 /* AppDelegate.swift in Sources */,
 				A459003827E8D107003010A0 /* SettingsViewController.swift in Sources */,
 				A4C1AFCE27E4F8150096CD3E /* UIView+FadeInOut.swift in Sources */,

--- a/Happiggy-bank/Happiggy-bank.xcodeproj/project.pbxproj
+++ b/Happiggy-bank/Happiggy-bank.xcodeproj/project.pbxproj
@@ -153,6 +153,8 @@
 		A843332127DA026D00A12A54 /* NewBottleDatePickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A843332027DA026D00A12A54 /* NewBottleDatePickerViewController.swift */; };
 		A843332427DA397800A12A54 /* DataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A843332327DA397800A12A54 /* DataProvider.swift */; };
 		A8509E6E27C89A1200855153 /* UIColor+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8509E6D27C89A1200855153 /* UIColor+Extension.swift */; };
+		A85B38862990CE7700ED8C72 /* NewBottleNameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A85B38852990CE7700ED8C72 /* NewBottleNameView.swift */; };
+		A85B38882990D5F000ED8C72 /* NewBottleNameViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A85B38872990D5F000ED8C72 /* NewBottleNameViewController.swift */; };
 		A89CBEDD27CBDEA2005549F6 /* BottleListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A89CBEDC27CBDEA2005549F6 /* BottleListViewController.swift */; };
 		A89FF2F12959902C00BF0E1B /* HomeTabViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A89FF2F02959902C00BF0E1B /* HomeTabViewModel.swift */; };
 		A8BD833327BE104900E0DE41 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8BD833227BE104900E0DE41 /* HomeViewController.swift */; };
@@ -325,6 +327,8 @@
 		A843332027DA026D00A12A54 /* NewBottleDatePickerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewBottleDatePickerViewController.swift; sourceTree = "<group>"; };
 		A843332327DA397800A12A54 /* DataProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataProvider.swift; sourceTree = "<group>"; };
 		A8509E6D27C89A1200855153 /* UIColor+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Extension.swift"; sourceTree = "<group>"; };
+		A85B38852990CE7700ED8C72 /* NewBottleNameView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewBottleNameView.swift; sourceTree = "<group>"; };
+		A85B38872990D5F000ED8C72 /* NewBottleNameViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewBottleNameViewController.swift; sourceTree = "<group>"; };
 		A89CBEDC27CBDEA2005549F6 /* BottleListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottleListViewController.swift; sourceTree = "<group>"; };
 		A89FF2F02959902C00BF0E1B /* HomeTabViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeTabViewModel.swift; sourceTree = "<group>"; };
 		A8BD833227BE104900E0DE41 /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
@@ -555,6 +559,14 @@
 				A4EDFE7E2902D5CB0056C2DC /* ColorPickerDelegate.swift */,
 			);
 			path = Protocol;
+			sourceTree = "<group>";
+		};
+		A85B38842990CE5B00ED8C72 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				A85B38852990CE7700ED8C72 /* NewBottleNameView.swift */,
+			);
+			path = View;
 			sourceTree = "<group>";
 		};
 		A896FBD12966B15600A3400B /* Controller */ = {
@@ -822,6 +834,7 @@
 		A896FBF22966B5E700A3400B /* UI */ = {
 			isa = PBXGroup;
 			children = (
+				A85B38842990CE5B00ED8C72 /* View */,
 				A896FBF32966B5E800A3400B /* Controller */,
 			);
 			path = UI;
@@ -831,6 +844,7 @@
 			isa = PBXGroup;
 			children = (
 				A843331E27DA013800A12A54 /* NewBottleNameFieldViewController.swift */,
+				A85B38872990D5F000ED8C72 /* NewBottleNameViewController.swift */,
 				A843332027DA026D00A12A54 /* NewBottleDatePickerViewController.swift */,
 				D236DB8727FDD66900D7B8F0 /* NewBottleMessageFieldViewController.swift */,
 			);
@@ -1342,6 +1356,7 @@
 				A81148E0295571A2004A35E7 /* HomeTabViewController.swift in Sources */,
 				A425F8B827EDF59A00A005AB /* TagCell.swift in Sources */,
 				A4B2860F27D9F539008769EB /* NewNoteDatePickerViewModel.swift in Sources */,
+				A85B38862990CE7700ED8C72 /* NewBottleNameView.swift in Sources */,
 				A467B5C827DA258700AC702D /* NewNoteDatePickerRowView.swift in Sources */,
 				A484A3052958945E00A58312 /* BaseTextView.swift in Sources */,
 				A41DE62B27F36E95002A7669 /* NoteCell.swift in Sources */,
@@ -1392,6 +1407,7 @@
 				A8ECD4A727E33BFA00886BC0 /* BottleListViewModel.swift in Sources */,
 				A49AC5EB2917FFAB009315BC /* PhotoNoteCellViewModel.swift in Sources */,
 				A484A32B296004E600A58312 /* Version.swift in Sources */,
+				A85B38882990D5F000ED8C72 /* NewBottleNameViewController.swift in Sources */,
 				A484A317295D619A00A58312 /* NetworkManager.swift in Sources */,
 				A49A8C212952F54900D5468A /* DebugPrint.swift in Sources */,
 				A4A55A0728FFC664004ABE00 /* UIView+ConfigureXib.swift in Sources */,

--- a/Happiggy-bank/Happiggy-bank.xcodeproj/project.pbxproj
+++ b/Happiggy-bank/Happiggy-bank.xcodeproj/project.pbxproj
@@ -116,7 +116,7 @@
 		A4B285FD27D8A060008769EB /* Calendar+Duration.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4B285FC27D8A060008769EB /* Calendar+Duration.swift */; };
 		A4B2860527D9A546008769EB /* NewNoteDatePickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4B2860427D9A546008769EB /* NewNoteDatePickerViewController.swift */; };
 		A4B2860927D9A56A008769EB /* NewNoteTextViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4B2860827D9A56A008769EB /* NewNoteTextViewController.swift */; };
-		A4B2860B27D9B434008769EB /* UIViewController+FadeOut.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4B2860A27D9B434008769EB /* UIViewController+FadeOut.swift */; };
+		A4B2860B27D9B434008769EB /* UIViewController+FadeInOut.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4B2860A27D9B434008769EB /* UIViewController+FadeInOut.swift */; };
 		A4B2860F27D9F539008769EB /* NewNoteDatePickerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4B2860E27D9F539008769EB /* NewNoteDatePickerViewModel.swift */; };
 		A4C1AFC027E477180096CD3E /* NSMutableAttributedString+ColorBold.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4C1AFBF27E477180096CD3E /* NSMutableAttributedString+ColorBold.swift */; };
 		A4C1AFC227E47AD80096CD3E /* String+EmptyString.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4C1AFC127E47AD80096CD3E /* String+EmptyString.swift */; };
@@ -151,6 +151,7 @@
 		A824A0B027CE72C000B99E9A /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = A824A0AF27CE72C000B99E9A /* Then */; };
 		A83CA2AF2993587300081E07 /* NewBottleMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83CA2AE2993587300081E07 /* NewBottleMessageView.swift */; };
 		A83CA2B1299359DB00081E07 /* NewBottleMessageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83CA2B0299359DB00081E07 /* NewBottleMessageViewController.swift */; };
+		A83CA2B32993669800081E07 /* UINavigationController+transition.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83CA2B22993669800081E07 /* UINavigationController+transition.swift */; };
 		A843331F27DA013800A12A54 /* NewBottleNameFieldViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A843331E27DA013800A12A54 /* NewBottleNameFieldViewController.swift */; };
 		A843332127DA026D00A12A54 /* NewBottleDatePickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A843332027DA026D00A12A54 /* NewBottleDatePickerViewController.swift */; };
 		A843332427DA397800A12A54 /* DataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A843332327DA397800A12A54 /* DataProvider.swift */; };
@@ -294,7 +295,7 @@
 		A4B285FC27D8A060008769EB /* Calendar+Duration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Calendar+Duration.swift"; sourceTree = "<group>"; };
 		A4B2860427D9A546008769EB /* NewNoteDatePickerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewNoteDatePickerViewController.swift; sourceTree = "<group>"; };
 		A4B2860827D9A56A008769EB /* NewNoteTextViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewNoteTextViewController.swift; sourceTree = "<group>"; };
-		A4B2860A27D9B434008769EB /* UIViewController+FadeOut.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+FadeOut.swift"; sourceTree = "<group>"; };
+		A4B2860A27D9B434008769EB /* UIViewController+FadeInOut.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+FadeInOut.swift"; sourceTree = "<group>"; };
 		A4B2860E27D9F539008769EB /* NewNoteDatePickerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewNoteDatePickerViewModel.swift; sourceTree = "<group>"; };
 		A4C1AFBF27E477180096CD3E /* NSMutableAttributedString+ColorBold.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSMutableAttributedString+ColorBold.swift"; sourceTree = "<group>"; };
 		A4C1AFC127E47AD80096CD3E /* String+EmptyString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+EmptyString.swift"; sourceTree = "<group>"; };
@@ -329,6 +330,7 @@
 		A819CFA027DE034F00DE8E72 /* NewBottle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewBottle.swift; sourceTree = "<group>"; };
 		A83CA2AE2993587300081E07 /* NewBottleMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewBottleMessageView.swift; sourceTree = "<group>"; };
 		A83CA2B0299359DB00081E07 /* NewBottleMessageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewBottleMessageViewController.swift; sourceTree = "<group>"; };
+		A83CA2B22993669800081E07 /* UINavigationController+transition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINavigationController+transition.swift"; sourceTree = "<group>"; };
 		A843331E27DA013800A12A54 /* NewBottleNameFieldViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewBottleNameFieldViewController.swift; sourceTree = "<group>"; };
 		A843332027DA026D00A12A54 /* NewBottleDatePickerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewBottleDatePickerViewController.swift; sourceTree = "<group>"; };
 		A843332327DA397800A12A54 /* DataProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataProvider.swift; sourceTree = "<group>"; };
@@ -1056,7 +1058,7 @@
 		A896FC182966BC3900A3400B /* UIViewController */ = {
 			isa = PBXGroup;
 			children = (
-				A4B2860A27D9B434008769EB /* UIViewController+FadeOut.swift */,
+				A4B2860A27D9B434008769EB /* UIViewController+FadeInOut.swift */,
 				A4CF2C8D27CBA49D001B01B1 /* UIViewController+NotificationCenter.swift */,
 				A466A30D28018BBD00D655F4 /* UIVIewController+TopMostViewController.swift */,
 				A46B10F128142F26004AB185 /* UIViewController+ObserveCustomFontChange.swift */,
@@ -1210,6 +1212,7 @@
 				A4D357E1283A4429007819E3 /* URL+Open.swift */,
 				A49AC5E82917CBFB009315BC /* UIStackView+AddArrangedSubviews.swift */,
 				A484A312295A972200A58312 /* Array+SafeIndex.swift */,
+				A83CA2B22993669800081E07 /* UINavigationController+transition.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1428,7 +1431,7 @@
 				A843332427DA397800A12A54 /* DataProvider.swift in Sources */,
 				A48E183A27E71D9300B44477 /* UILabel+ParagraphStyle.swift in Sources */,
 				A8F985E2296FF37000E5ACC6 /* BottleCollectionCell.swift in Sources */,
-				A4B2860B27D9B434008769EB /* UIViewController+FadeOut.swift in Sources */,
+				A4B2860B27D9B434008769EB /* UIViewController+FadeInOut.swift in Sources */,
 				A484A31C295D75F900A58312 /* NetworkError.swift in Sources */,
 				A49AC5E52917C6E2009315BC /* UILabel+ChangeFontSize.swift in Sources */,
 				A4A55A0928FFC675004ABE00 /* NewNoteInputView.swift in Sources */,
@@ -1446,6 +1449,7 @@
 				A456657E27CC77A9007CF70A /* Date+Formatted.swift in Sources */,
 				A81742FF27C108DC0016C921 /* HomeViewModel.swift in Sources */,
 				A484A32D296015D600A58312 /* Publisher.swift in Sources */,
+				A83CA2B32993669800081E07 /* UINavigationController+transition.swift in Sources */,
 				A4CF2C9027CBA66F001B01B1 /* NSNotificaion.Name+CustomNotifications.swift in Sources */,
 				D2AB663E27FFFCF50003AC8C /* UpdateSender.swift in Sources */,
 				A4B285FD27D8A060008769EB /* Calendar+Duration.swift in Sources */,

--- a/Happiggy-bank/Happiggy-bank.xcodeproj/project.pbxproj
+++ b/Happiggy-bank/Happiggy-bank.xcodeproj/project.pbxproj
@@ -162,6 +162,8 @@
 		A8BD833F27BE30B400E0DE41 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8BD833E27BE30B400E0DE41 /* Constants.swift */; };
 		A8BD834727BE337900E0DE41 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8BD834627BE337900E0DE41 /* HomeView.swift */; };
 		A8C972032952C88D00CB59F9 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = A8C972022952C88D00CB59F9 /* SnapKit */; };
+		A8D58DB0299286A700FD52A1 /* NewBottleDateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8D58DAF299286A700FD52A1 /* NewBottleDateView.swift */; };
+		A8D58DB229928AA900FD52A1 /* NewBottleDateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8D58DB129928AA900FD52A1 /* NewBottleDateViewController.swift */; };
 		A8EB5E8B27C8B087005704F2 /* UIButton+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8EB5E8A27C8B087005704F2 /* UIButton+Extension.swift */; };
 		A8ECD4A727E33BFA00886BC0 /* BottleListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8ECD4A627E33BFA00886BC0 /* BottleListViewModel.swift */; };
 		A8F985E0296FDE6000E5ACC6 /* ListTabViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8F985DF296FDE6000E5ACC6 /* ListTabViewController.swift */; };
@@ -335,6 +337,8 @@
 		A8BD833427BE106C00E0DE41 /* BottleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottleViewController.swift; sourceTree = "<group>"; };
 		A8BD833E27BE30B400E0DE41 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		A8BD834627BE337900E0DE41 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
+		A8D58DAF299286A700FD52A1 /* NewBottleDateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewBottleDateView.swift; sourceTree = "<group>"; };
+		A8D58DB129928AA900FD52A1 /* NewBottleDateViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewBottleDateViewController.swift; sourceTree = "<group>"; };
 		A8EB5E8A27C8B087005704F2 /* UIButton+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+Extension.swift"; sourceTree = "<group>"; };
 		A8ECD4A627E33BFA00886BC0 /* BottleListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottleListViewModel.swift; sourceTree = "<group>"; };
 		A8F985DF296FDE6000E5ACC6 /* ListTabViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListTabViewController.swift; sourceTree = "<group>"; };
@@ -565,6 +569,7 @@
 			isa = PBXGroup;
 			children = (
 				A85B38852990CE7700ED8C72 /* NewBottleNameView.swift */,
+				A8D58DAF299286A700FD52A1 /* NewBottleDateView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -847,6 +852,7 @@
 				A85B38872990D5F000ED8C72 /* NewBottleNameViewController.swift */,
 				A843332027DA026D00A12A54 /* NewBottleDatePickerViewController.swift */,
 				D236DB8727FDD66900D7B8F0 /* NewBottleMessageFieldViewController.swift */,
+				A8D58DB129928AA900FD52A1 /* NewBottleDateViewController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -1471,7 +1477,9 @@
 				A8BD833327BE104900E0DE41 /* HomeViewController.swift in Sources */,
 				A499318127BF3A38009FF5A8 /* BottleViewModel.swift in Sources */,
 				A4396B1929323131005D9D3A /* ImageManager.swift in Sources */,
+				A8D58DB0299286A700FD52A1 /* NewBottleDateView.swift in Sources */,
 				A4D6EB77282E307900553E43 /* VersionManager.swift in Sources */,
+				A8D58DB229928AA900FD52A1 /* NewBottleDateViewController.swift in Sources */,
 				A44E901727D5EB130053AC57 /* Happiggy-bank.xcdatamodeld in Sources */,
 				A4534714285071A800F77164 /* Date+Tomorrow.swift in Sources */,
 				A4C1AFD427E5E6120096CD3E /* UITextView+ParagraphStyle.swift in Sources */,

--- a/Happiggy-bank/Happiggy-bank/HomeTab/Home/UI/Controller/HomeTabViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/HomeTab/Home/UI/Controller/HomeTabViewController.swift
@@ -73,7 +73,7 @@ final class HomeTabViewController: UIViewController {
         else {
             // NewBottleNameViewController
             self.navigationController?.pushViewController(
-                UIViewController().then { $0.view.backgroundColor = .yellow },
+                NewBottleNameViewController(),
                 animated: false
             )
             return

--- a/Happiggy-bank/Happiggy-bank/HomeTab/Home/UI/Controller/HomeTabViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/HomeTab/Home/UI/Controller/HomeTabViewController.swift
@@ -71,10 +71,8 @@ final class HomeTabViewController: UIViewController {
     @objc private func viewDidTap(_ sender: UITapGestureRecognizer) {
         guard let bottle = self.viewModel.bottle
         else {
-            // NewBottleNameViewController
-            self.navigationController?.pushViewController(
-                NewBottleNameViewController(),
-                animated: false
+            self.navigationController?.pushViewControllerWithFade(
+                to: NewBottleNameViewController()
             )
             return
         }
@@ -88,15 +86,13 @@ final class HomeTabViewController: UIViewController {
         
         if bottle.isEmtpyToday {
             // NewNoteTextViewController
-            self.navigationController?.pushViewController(
-                UIViewController().then { $0.view.backgroundColor = .gray },
-                animated: false
+            self.navigationController?.pushViewControllerWithFade(
+                to: UIViewController().then { $0.view.backgroundColor = .gray }
             )
         } else {
             // NewNoteDatePickerViewController
-            self.navigationController?.pushViewController(
-                UIViewController().then { $0.view.backgroundColor = .orange },
-                animated: false
+            self.navigationController?.pushViewControllerWithFade(
+                to: UIViewController().then { $0.view.backgroundColor = .orange }
             )
         }
     }
@@ -189,9 +185,8 @@ extension HomeTabViewController {
     
     /// 메뉴 버튼에서 저금통 제목 변경을 선택했을 때 실행되는 함수
     private func changeBottleNameItemDidTap() {
-        self.navigationController?.pushViewController(
-            UIViewController().then { $0.view.backgroundColor = .blue },
-            animated: false
+        self.navigationController?.pushViewControllerWithFade(
+            to: UIViewController().then { $0.view.backgroundColor = .blue }
         )
         self.bottleViewController.alertOrModalDidAppear()
     }
@@ -237,9 +232,8 @@ extension HomeTabViewController {
         )
         HapticManager.instance.notification(type: .success)
         self.bottleViewController.bottleDidOpen(withDuration: Duration.bottleOpeningAnimation)
-        self.navigationController?.pushViewController(
-            UIViewController().then { $0.view.backgroundColor = .red },
-            animated: false
+        self.navigationController?.pushViewControllerWithFade(
+            to: UIViewController().then { $0.view.backgroundColor = .red }
         )
         self.viewModel.bottle = nil
 

--- a/Happiggy-bank/Happiggy-bank/HomeTab/NewBottle/UI/Controller/NewBottleDateViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/HomeTab/NewBottle/UI/Controller/NewBottleDateViewController.swift
@@ -29,8 +29,6 @@ class NewBottleDateViewController: UIViewController {
     // MARK: - Life Cycle
     
     override func loadView() {
-        super.loadView()
-        
         self.view = self.newBottleDateView
     }
     

--- a/Happiggy-bank/Happiggy-bank/HomeTab/NewBottle/UI/Controller/NewBottleDateViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/HomeTab/NewBottle/UI/Controller/NewBottleDateViewController.swift
@@ -52,16 +52,13 @@ class NewBottleDateViewController: UIViewController {
         // 이전 화면으로 돌아가기
         self.delegate?.send(self.viewModel.bottleData ?? NewBottle())
         
-        self.fadeOut()
-        self.navigationController?.popViewController(animated: false)
+        self.navigationController?.popViewControllerWithFade()
     }
     
     /// 새 유리병 개봉 멘트 입력 뷰 컨트롤러로 이동하는 next button 액션
     @objc func nextButtonDidTap(_ sender: Any) {
-        self.fadeOut()
-        self.navigationController?.pushViewController(
-            prepareNextViewController(),
-            animated: false
+        self.navigationController?.pushViewControllerWithFade(
+            to: prepareNextViewController()
         )
     }
     

--- a/Happiggy-bank/Happiggy-bank/HomeTab/NewBottle/UI/Controller/NewBottleDateViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/HomeTab/NewBottle/UI/Controller/NewBottleDateViewController.swift
@@ -1,0 +1,229 @@
+//
+//  NewBottleDateViewController.swift
+//  Happiggy-bank
+//
+//  Created by 권은빈 on 2023/02/07.
+//
+
+import UIKit
+
+import SnapKit
+
+
+// MARK: - Ver2부터 뷰모델, 해당 뷰 컨트롤러, 뷰 모두 변경될 예정이라 코드 수정 별도로 안 했습니다
+
+class NewBottleDateViewController: UIViewController {
+    
+    // MARK: - Properties
+    
+    /// newBottleDateView
+    var newBottleDateView: NewBottleDateView = NewBottleDateView()
+    
+    /// 유리병 데이터 전달하는 델리게이트
+    var delegate: DataProvider?
+    
+    /// 데이터 가공해 전달하는 뷰모델
+    var viewModel: NewBottleDatePickerViewModel = NewBottleDatePickerViewModel()
+
+    
+    // MARK: - Life Cycle
+    
+    override func loadView() {
+        super.loadView()
+        
+        self.view = self.newBottleDateView
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        initializePickerView()
+        configureNavigationItems()
+        configureDescriptionLabel()
+        setPickerHighlightWhite()
+    }
+
+    
+    // MARK: @objc functions
+    
+    /// 새 유리병 이름 입력하는 뷰 컨트롤러로 돌아가는 back button 액션
+    /// 이전으로 돌아가도 현재 입력된 피커의 값이 저장되어야 하므로 델리게이트 함수 사용
+    @objc func backButtonDidTap(_ sender: UIBarButtonItem) {
+        // 이전 화면으로 돌아가기
+        self.delegate?.send(self.viewModel.bottleData ?? NewBottle())
+        
+        self.fadeOut()
+        self.navigationController?.popViewController(animated: false)
+    }
+    
+    /// 새 유리병 개봉 멘트 입력 뷰 컨트롤러로 이동하는 next button 액션
+    @objc func nextButtonDidTap(_ sender: Any) {
+        // navigate to newBottleMessageViewController
+    }
+    
+    
+    // MARK: configurations
+    
+    /// 내비게이션 바의 왼쪽, 오른쪽 버튼 아이템 설정
+    private func configureNavigationItems() {
+        let back = UIBarButtonItem(
+            image: AssetImage.back,
+            style: .plain,
+            target: self,
+            action: #selector(backButtonDidTap)
+        )
+        let next = UIBarButtonItem(
+            image: AssetImage.next,
+            style: .plain,
+            target: self,
+            action: #selector(nextButtonDidTap)
+        )
+        
+        self.navigationItem.leftBarButtonItem = back
+        self.navigationItem.rightBarButtonItem = next
+        self.navigationItem.title = Text.navigationBarTitle
+    }
+    
+    /// 개봉 예정일 라벨 세팅
+    private func configureDescriptionLabel() {
+        guard let periodIndex = self.viewModel.bottleData?.periodIndex
+        else { return }
+        let endDate = viewModel.endDate(
+            from: Date(),
+            after: periodIndex
+        )
+        self.newBottleDateView.descriptionLabel.text = viewModel.openDateString(of: endDate)
+    }
+    
+    /// 피커 뷰 초기 상태 세팅하는 함수
+    /// 처음엔 가운데로, 이후엔 선택된 행의 인덱스에 따라 설정됨
+    private func initializePickerView() {
+        let row = self.viewModel.bottleData?.periodIndex ??
+        NewBottleDateViewController.pickerValues.count / 2
+        
+        self.newBottleDateView.pickerView.delegate = self
+        self.newBottleDateView.pickerView.dataSource = self
+        self.newBottleDateView.pickerView.selectRow(
+            row,
+            inComponent: 0,
+            animated: false
+        )
+        self.updateSelectedRow(
+            self.newBottleDateView.pickerView,
+            row: row,
+            component: 0
+        )
+        self.viewModel.bottleData?.periodIndex = row
+        self.viewModel.bottleData?.endDate = viewModel.endDate(from: Date(), after: row)
+    }
+    
+    /// 피커 선택 하이라이트 뷰 흰색으로 설정하는 함수
+    private func setPickerHighlightWhite() {
+        guard let defaultHightlightView = self.newBottleDateView.pickerView.subviews.last
+        else { return }
+        
+        defaultHightlightView.backgroundColor = .clear
+        
+        let highlightView = UIView().then {
+            $0.backgroundColor = .white
+            $0.layer.cornerRadius = defaultHightlightView.layer.cornerRadius
+            $0.frame = defaultHightlightView.frame
+        }
+        
+        self.view.insertSubview(highlightView, belowSubview: self.newBottleDateView.pickerView)
+        highlightView.snp.makeConstraints { make in
+            make.center.equalToSuperview()
+            make.width.equalTo(defaultHightlightView.snp.width)
+            make.height.equalTo(defaultHightlightView.snp.height)
+        }
+    }
+}
+
+extension NewBottleDateViewController: DataProvider {
+    
+    /// 유리병 데이터에 delegate를 통해 받아온 데이터를 대입해주는 함수
+    func send(_ data: NewBottle) {
+        self.viewModel.bottleData = data
+    }
+}
+
+extension NewBottleDateViewController: UIPickerViewDataSource {
+    
+    /// 피커 뷰의 휠 개수
+    func numberOfComponents(in pickerView: UIPickerView) -> Int {
+        return 1
+    }
+    
+    /// 피커 뷰의 선택지 개수
+    func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
+        return NewBottleDateViewController.pickerValues.count
+    }
+}
+
+extension NewBottleDateViewController: UIPickerViewDelegate {
+    
+    /// 피커 각 행 구성
+    func pickerView(
+        _ pickerView: UIPickerView,
+        viewForRow row: Int,
+        forComponent component: Int,
+        reusing view: UIView?
+    ) -> UIView {
+        
+        return BaseLabel().then {
+            $0.text = NewBottleDateViewController.pickerValues[row]
+            $0.font = .systemFont(ofSize: FontSize.body1)
+            $0.textAlignment = .center
+        }
+    }
+    
+    /// 피커 뷰의 선택된 항목
+    func pickerView(
+        _ pickerView: UIPickerView,
+        didSelectRow row: Int,
+        inComponent component: Int
+    ) {
+        self.viewModel.bottleData?.periodIndex = row
+        self.viewModel.bottleData?.endDate = viewModel.endDate(from: Date(), after: row)
+        self.updateSelectedRow(
+            pickerView,
+            row: row,
+            component: component
+        )
+    }
+
+    /// 피커 선택된 상태로 업데이트
+    private func updateSelectedRow(
+        _ pickerView: UIPickerView,
+        row: Int,
+        component: Int
+    ) {
+        guard let rowView = pickerView.view(forRow: row, forComponent: component)
+                as? BaseLabel
+        else { return }
+
+        rowView.textColor = AssetColor.mainGreen
+        configureDescriptionLabel()
+    }
+}
+
+extension NewBottleDateViewController {
+    
+    /// NewBottleDateViewController의 Picker 선택지
+    static let pickerValues = ["일주일", "한 달", "3달", "6달", "일 년"]
+    
+    /// DateComponents를 만들기 위한 Picker의 상수값
+    static let pickerConstants: [String: Int] = [
+        pickerValues[0] : 7,
+        pickerValues[1] : 1,
+        pickerValues[2] : 3,
+        pickerValues[3] : 6,
+        pickerValues[4] : 1
+    ]
+    
+    enum Text {
+        
+        /// 내비게이션 바 타이틀
+        static let navigationBarTitle: String = "개인 저금통 만들기"
+    }
+}

--- a/Happiggy-bank/Happiggy-bank/HomeTab/NewBottle/UI/Controller/NewBottleDateViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/HomeTab/NewBottle/UI/Controller/NewBottleDateViewController.swift
@@ -12,7 +12,7 @@ import SnapKit
 
 // MARK: - Ver2부터 뷰모델, 해당 뷰 컨트롤러, 뷰 모두 변경될 예정이라 코드 수정 별도로 안 했습니다
 
-class NewBottleDateViewController: UIViewController {
+final class NewBottleDateViewController: UIViewController {
     
     // MARK: - Properties
     

--- a/Happiggy-bank/Happiggy-bank/HomeTab/NewBottle/UI/Controller/NewBottleDateViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/HomeTab/NewBottle/UI/Controller/NewBottleDateViewController.swift
@@ -58,7 +58,11 @@ class NewBottleDateViewController: UIViewController {
     
     /// 새 유리병 개봉 멘트 입력 뷰 컨트롤러로 이동하는 next button 액션
     @objc func nextButtonDidTap(_ sender: Any) {
-        // navigate to newBottleMessageViewController
+        self.fadeOut()
+        self.navigationController?.pushViewController(
+            prepareNextViewController(),
+            animated: false
+        )
     }
     
     
@@ -136,6 +140,16 @@ class NewBottleDateViewController: UIViewController {
             make.width.equalTo(defaultHightlightView.snp.width)
             make.height.equalTo(defaultHightlightView.snp.height)
         }
+    }
+    
+    /// 다음 뷰 컨트롤러 설정
+    private func prepareNextViewController() -> UIViewController {
+        let newBottleMessageViewController = NewBottleMessageViewController()
+        
+        newBottleMessageViewController.delegate = self
+        newBottleMessageViewController.bottleData = self.viewModel.bottleData
+        
+        return newBottleMessageViewController
     }
 }
 

--- a/Happiggy-bank/Happiggy-bank/HomeTab/NewBottle/UI/Controller/NewBottleMessageViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/HomeTab/NewBottle/UI/Controller/NewBottleMessageViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class NewBottleMessageViewController: UIViewController {
+final class NewBottleMessageViewController: UIViewController {
 
     // MARK: - Properties
     

--- a/Happiggy-bank/Happiggy-bank/HomeTab/NewBottle/UI/Controller/NewBottleMessageViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/HomeTab/NewBottle/UI/Controller/NewBottleMessageViewController.swift
@@ -1,0 +1,29 @@
+//
+//  NewBottleMessageViewController.swift
+//  Happiggy-bank
+//
+//  Created by 권은빈 on 2023/02/08.
+//
+
+import UIKit
+
+class NewBottleMessageViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/Happiggy-bank/Happiggy-bank/HomeTab/NewBottle/UI/Controller/NewBottleMessageViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/HomeTab/NewBottle/UI/Controller/NewBottleMessageViewController.swift
@@ -24,8 +24,6 @@ class NewBottleMessageViewController: UIViewController {
     // MARK: - Life Cycles
     
     override func loadView() {
-        super.loadView()
-        
         self.view = self.newBottleMessageView
     }
     

--- a/Happiggy-bank/Happiggy-bank/HomeTab/NewBottle/UI/Controller/NewBottleMessageViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/HomeTab/NewBottle/UI/Controller/NewBottleMessageViewController.swift
@@ -9,21 +9,251 @@ import UIKit
 
 class NewBottleMessageViewController: UIViewController {
 
-    override func viewDidLoad() {
-        super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
+    // MARK: - Properties
+    
+    /// 컨트롤러의 메인 뷰
+    var newBottleMessageView: NewBottleMessageView = NewBottleMessageView()
+    
+    /// 새로 생성중인 저금통 데이터
+    var bottleData: NewBottle!
+    
+    /// 저금통 데이터 전달하는 델리게이트
+    var delegate: DataProvider?
+    
+    
+    // MARK: - Life Cycles
+    
+    override func loadView() {
+        super.loadView()
+        
+        self.view = self.newBottleMessageView
     }
     
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureNavigationItems()
+        configureTextField()
     }
-    */
+    
+    
+    // MARK: - objc functions
+    
+    /// back 버튼이 눌렸을 때 호출되는 함수
+    @objc func backButtonDidTap(_ sender: UIBarButtonItem) {
+        self.newBottleMessageView.textField.endEditing(true)
+        // 이전 화면으로 돌아가기
+        guard let message = self.newBottleMessageView.textField.text
+        else { return }
+        
+        self.bottleData.openMessage = message
+        self.delegate?.send(self.bottleData ?? NewBottle())
+        
+        self.fadeOut()
+        self.navigationController?.popViewController(animated: false)
+    }
+    
+    /// 새 유리병 데이터를 코어데이터에 저장하고 홈 뷰 컨트롤러로 되돌아가는 save button 액션
+    @objc func saveButtonDidTap(_ sender: UIBarButtonItem) {
+        self.newBottleMessageView.textField.endEditing(true)
+        self.present(self.confirmationAlert(), animated: true)
+    }
 
+    
+    // MARK: - configurations
+    
+    /// 내비게이션 바의 왼쪽, 오른쪽 버튼 아이템 설정
+    private func configureNavigationItems() {
+        let back = UIBarButtonItem(
+            image: AssetImage.back,
+            style: .plain,
+            target: self,
+            action: #selector(backButtonDidTap)
+        )
+        let save = UIBarButtonItem(
+            image: AssetImage.checkmark,
+            style: .plain,
+            target: self,
+            action: #selector(saveButtonDidTap)
+        )
+        
+        self.navigationItem.leftBarButtonItem = back
+        self.navigationItem.rightBarButtonItem = save
+        self.navigationItem.title = Text.navigationBarTitle
+    }
+    
+    /// 텍스트필드 설정
+    private func configureTextField() {
+        self.newBottleMessageView.textField.delegate = self
+        self.newBottleMessageView.textField.becomeFirstResponder()
+    }
+    
+    
+    // MARK: - Functions
+    
+    // TODO: - fetchedResultsController로 변경
+    /// 새 저금통 저장하는 메서드
+    private func saveNewBottle() -> Bool {
+        self.bottleData.openMessage = self.newBottleMessageView.textField.text
+        
+        guard let title = self.bottleData?.name,
+              let endDate = self.bottleData?.endDate
+        else { return false }
+        
+        var bottle: Bottle
+        
+        if let openMessage = self.bottleData.openMessage, !openMessage.isEmpty {
+            bottle = Bottle(
+                title: title,
+                startDate: Date(),
+                endDate: endDate,
+                message: openMessage
+            )
+        } else {
+            bottle = Bottle(
+                title: title,
+                startDate: Date(),
+                endDate: endDate,
+                message: Text.defaultMessage
+            )
+        }
+        
+        guard let (errorTitle, errorMessage) = PersistenceStore.shared.saveOld()
+        else { return true }
+        
+        let alert = PersistenceStore.shared.makeErrorAlert(
+            title: errorTitle,
+            message: errorMessage
+        ) { _ in
+            self.fadeOut()
+            self.navigationController?.popToRootViewController(animated: false)
+        }
+        
+        PersistenceStore.shared.delete(bottle)
+        self.present(alert, animated: true)
+        return false
+    }
+    
+    /// 생성 확인 알림을 나타냄
+    private func confirmationAlert() -> UIAlertController {
+        let confirmAction = UIAlertAction.confirmAction(
+            title: Text.confirmationAlertConfirmButtonTitle
+        ) { _ in
+            guard self.saveNewBottle() == true
+            else { return }
+            
+            self.fadeOut()
+            self.navigationController?.popToRootViewController(animated: false)
+        }
+        
+        let cancelAction = UIAlertAction.cancelAction { _ in
+            self.newBottleMessageView.textField.becomeFirstResponder()
+        }
+        
+        return UIAlertController.basic(
+            alertTitle: Text.confirmationAlertTitle,
+            alertMessage: Text.confirmationAlertMessage,
+            confirmAction: confirmAction,
+            cancelAction: cancelAction
+        )
+    }
+}
+
+extension NewBottleMessageViewController: DataProvider {
+    
+    /// 유리병 데이터에 delegate를 통해 받아온 데이터를 대입해주는 함수
+    func send(_ data: NewBottle) {
+        self.bottleData = data
+        self.newBottleMessageView.textField.becomeFirstResponder()
+    }
+}
+
+extension NewBottleMessageViewController: UITextFieldDelegate {
+    
+    func textFieldDidEndEditing(_ textField: UITextField) {
+        guard let text = textField.text,
+              text.count > Metric.maxLength
+        else { return }
+        
+        textField.text = String(text.prefix(Metric.maxLength))
+        self.newBottleMessageView.textField.resignFirstResponder()
+    }
+    
+    /// 리턴 키를 눌렀을 때 자동으로 다음 뷰로 넘어가며, 텍스트필드의 firstResponder 해제
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.endEditing(true)
+        self.present(self.confirmationAlert(), animated: true)
+        
+        return true
+    }
+    
+    /// 최대 글자수 15자 제한
+    func textField(
+        _ textField: UITextField,
+        shouldChangeCharactersIn range: NSRange,
+        replacementString string: String
+    ) -> Bool {
+        
+        // 텍스트가 유효한지, 편집한 범위를 찾을 수 있는 지 확인
+        guard let currentText = textField.text,
+              Range(range, in: currentText) != nil
+        else { return false }
+        
+        let maxLength = Metric.maxLength + 1
+
+        let updatedTextLength = currentText.count - range.length + string.count
+        let trimLength = updatedTextLength - maxLength
+
+        guard updatedTextLength > maxLength,
+              string.count >= trimLength
+        else { return true }
+        
+        // 새로 입력된 문자열의 초과분을 삭제
+        let index = string.index(string.endIndex, offsetBy: -trimLength)
+        let trimmedReplacementText = string[..<index]
+        
+        guard let startPosition = textField.position(
+            from: textField.beginningOfDocument,
+            offset: range.location
+        ),
+              let endPosition = textField.position(
+                from: textField.beginningOfDocument,
+                offset: NSMaxRange(range)
+              ),
+              let textRange = textField.textRange(
+                from: startPosition,
+                to: endPosition
+              )
+        else { return false }
+              
+        textField.replace(textRange, withText: String(trimmedReplacementText))
+        
+        return false
+    }
+}
+
+extension NewBottleMessageViewController {
+    
+    enum Metric {
+        
+        /// 새 저금통 생성시 설정하는 한마디 최대 글자수(15자)
+        static let maxLength: Int = 15
+    }
+    
+    enum Text {
+        
+        /// 내비게이션 바 타이틀
+        static let navigationBarTitle: String = "개인 저금통 만들기"
+        
+        /// 한마디 입력하지 않았을 시 자동으로 설정되는 디폴트 메시지
+        static let defaultMessage: String = "반가워 내 행복들아!"
+        
+        /// 생성 확인 알림 제목
+        static let confirmationAlertTitle = "저금통을 추가하시겠어요?"
+        
+        /// 생성 확인 알림 내용
+        static let confirmationAlertMessage = "추가 후에는 개봉날짜 변경 및 저금통 삭제가 불가합니다."
+        
+        /// 생성 확인 알림 확인 버튼 제목: 추가
+        static let confirmationAlertConfirmButtonTitle = "추가"
+    }
 }

--- a/Happiggy-bank/Happiggy-bank/HomeTab/NewBottle/UI/Controller/NewBottleMessageViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/HomeTab/NewBottle/UI/Controller/NewBottleMessageViewController.swift
@@ -48,8 +48,7 @@ class NewBottleMessageViewController: UIViewController {
         self.bottleData.openMessage = message
         self.delegate?.send(self.bottleData ?? NewBottle())
         
-        self.fadeOut()
-        self.navigationController?.popViewController(animated: false)
+        self.navigationController?.popViewControllerWithFade()
     }
     
     /// 새 유리병 데이터를 코어데이터에 저장하고 홈 뷰 컨트롤러로 되돌아가는 save button 액션
@@ -124,8 +123,7 @@ class NewBottleMessageViewController: UIViewController {
             title: errorTitle,
             message: errorMessage
         ) { _ in
-            self.fadeOut()
-            self.navigationController?.popToRootViewController(animated: false)
+            self.navigationController?.popToRootViewControllerWithFade()
         }
         
         PersistenceStore.shared.delete(bottle)
@@ -141,8 +139,7 @@ class NewBottleMessageViewController: UIViewController {
             guard self.saveNewBottle() == true
             else { return }
             
-            self.fadeOut()
-            self.navigationController?.popToRootViewController(animated: false)
+            self.navigationController?.popToRootViewControllerWithFade()
         }
         
         let cancelAction = UIAlertAction.cancelAction { _ in

--- a/Happiggy-bank/Happiggy-bank/HomeTab/NewBottle/UI/Controller/NewBottleNameViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/HomeTab/NewBottle/UI/Controller/NewBottleNameViewController.swift
@@ -7,9 +7,6 @@
 
 import UIKit
 
-// TODO: - 1. fade in 효과 적용
-// TODO: - 2. prepare에 해당하는 함수 정의
-
 final class NewBottleNameViewController: UIViewController {
     
     // MARK: - Properties

--- a/Happiggy-bank/Happiggy-bank/HomeTab/NewBottle/UI/Controller/NewBottleNameViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/HomeTab/NewBottle/UI/Controller/NewBottleNameViewController.swift
@@ -38,8 +38,7 @@ final class NewBottleNameViewController: UIViewController {
     
     /// back 버튼이 눌렸을 때 호출되는 함수
     @objc func cancelButtonDidTap(_ sender: UIBarButtonItem) {
-        self.fadeOut()
-        self.navigationController?.popToRootViewController(animated: false)
+        self.navigationController?.popToRootViewControllerWithFade()
     }
     
     /// next 버튼이 눌렸을 때 호출되는 함수
@@ -53,9 +52,8 @@ final class NewBottleNameViewController: UIViewController {
             self.newBottleNameView.warningLabel.fadeIn()
         } else {
             self.newBottleNameView.textField.endEditing(true)
-            self.navigationController?.pushViewController(
-                prepareNextViewController(),
-                animated: false
+            self.navigationController?.pushViewControllerWithFade(
+                to: prepareNextViewController()
             )
         }
     }
@@ -151,9 +149,8 @@ extension NewBottleNameViewController: UITextFieldDelegate {
         if let text = self.newBottleNameView.textField.text,
            !text.isEmpty {
             self.newBottleNameView.textField.endEditing(true)
-            self.navigationController?.pushViewController(
-                prepareNextViewController(),
-                animated: false
+            self.navigationController?.pushViewControllerWithFade(
+                to: prepareNextViewController()
             )
             return true
         } else {

--- a/Happiggy-bank/Happiggy-bank/HomeTab/NewBottle/UI/Controller/NewBottleNameViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/HomeTab/NewBottle/UI/Controller/NewBottleNameViewController.swift
@@ -52,18 +52,9 @@ final class NewBottleNameViewController: UIViewController {
             self.newBottleNameView.warningLabel.isHidden = false
             self.newBottleNameView.warningLabel.fadeIn()
         } else {
-            let newBottleDateViewController = NewBottleDateViewController()
-            
-            newBottleDateViewController.delegate = self
-            newBottleDateViewController.viewModel.bottleData = NewBottle(
-                name: self.newBottleNameView.textField.text,
-                periodIndex: self.bottleData?.periodIndex,
-                openMessage: self.bottleData?.openMessage
-            )
-            
             self.newBottleNameView.textField.endEditing(true)
             self.navigationController?.pushViewController(
-                newBottleDateViewController,
+                prepareNextViewController(),
                 animated: false
             )
         }
@@ -119,6 +110,19 @@ final class NewBottleNameViewController: UIViewController {
             for: .editingChanged
         )
     }
+    
+    private func prepareNextViewController() -> UIViewController {
+        let newBottleDateViewController = NewBottleDateViewController()
+        
+        newBottleDateViewController.delegate = self
+        newBottleDateViewController.viewModel.bottleData = NewBottle(
+            name: self.newBottleNameView.textField.text,
+            periodIndex: self.bottleData?.periodIndex,
+            openMessage: self.bottleData?.openMessage
+        )
+        
+        return newBottleDateViewController
+    }
 }
 
 extension NewBottleNameViewController: DataProvider {
@@ -145,10 +149,10 @@ extension NewBottleNameViewController: UITextFieldDelegate {
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         if let text = self.newBottleNameView.textField.text,
            !text.isEmpty {
-            textField.endEditing(true)
-            self.performSegue(
-                withIdentifier: SegueIdentifier.presentNewBottleDatePicker,
-                sender: nil
+            self.newBottleNameView.textField.endEditing(true)
+            self.navigationController?.pushViewController(
+                prepareNextViewController(),
+                animated: false
             )
             return true
         } else {

--- a/Happiggy-bank/Happiggy-bank/HomeTab/NewBottle/UI/Controller/NewBottleNameViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/HomeTab/NewBottle/UI/Controller/NewBottleNameViewController.swift
@@ -1,0 +1,28 @@
+//
+//  NewBottleNameViewController.swift
+//  Happiggy-bank
+//
+//  Created by 권은빈 on 2023/02/06.
+//
+
+import UIKit
+
+final class NewBottleNameViewController: UIViewController {
+    
+    // MARK: - Properties
+    
+    var newBottleNameView: NewBottleNameView = NewBottleNameView()
+    
+    
+    // MARK: - Life Cycles
+    
+    override func loadView() {
+        super.loadView()
+        
+        self.view = self.newBottleNameView
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+}

--- a/Happiggy-bank/Happiggy-bank/HomeTab/NewBottle/UI/Controller/NewBottleNameViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/HomeTab/NewBottle/UI/Controller/NewBottleNameViewController.swift
@@ -52,8 +52,20 @@ final class NewBottleNameViewController: UIViewController {
             self.newBottleNameView.warningLabel.isHidden = false
             self.newBottleNameView.warningLabel.fadeIn()
         } else {
+            let newBottleDateViewController = NewBottleDateViewController()
+            
+            newBottleDateViewController.delegate = self
+            newBottleDateViewController.viewModel.bottleData = NewBottle(
+                name: self.newBottleNameView.textField.text,
+                periodIndex: self.bottleData?.periodIndex,
+                openMessage: self.bottleData?.openMessage
+            )
+            
             self.newBottleNameView.textField.endEditing(true)
-            // TODO: - 다음 viewController로 이동
+            self.navigationController?.pushViewController(
+                newBottleDateViewController,
+                animated: false
+            )
         }
     }
     

--- a/Happiggy-bank/Happiggy-bank/HomeTab/NewBottle/UI/Controller/NewBottleNameViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/HomeTab/NewBottle/UI/Controller/NewBottleNameViewController.swift
@@ -22,8 +22,6 @@ final class NewBottleNameViewController: UIViewController {
     // MARK: - Life Cycles
     
     override func loadView() {
-        super.loadView()
-        
         self.view = self.newBottleNameView
     }
     

--- a/Happiggy-bank/Happiggy-bank/HomeTab/NewBottle/UI/Controller/NewBottleNameViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/HomeTab/NewBottle/UI/Controller/NewBottleNameViewController.swift
@@ -111,6 +111,7 @@ final class NewBottleNameViewController: UIViewController {
         )
     }
     
+    /// 다음 뷰 컨트롤러 설정
     private func prepareNextViewController() -> UIViewController {
         let newBottleDateViewController = NewBottleDateViewController()
         

--- a/Happiggy-bank/Happiggy-bank/HomeTab/NewBottle/UI/Controller/NewBottleNameViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/HomeTab/NewBottle/UI/Controller/NewBottleNameViewController.swift
@@ -7,11 +7,16 @@
 
 import UIKit
 
+// TODO: - 1. fade in 효과 적용
+// TODO: - 2. prepare에 해당하는 함수 정의
+
 final class NewBottleNameViewController: UIViewController {
     
     // MARK: - Properties
     
     var newBottleNameView: NewBottleNameView = NewBottleNameView()
+    
+    var bottleData: NewBottle?
     
     
     // MARK: - Life Cycles
@@ -24,5 +29,177 @@ final class NewBottleNameViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        configureNavigationItems()
+        configureTextField()
+    }
+    
+    
+    // MARK: - objc functions
+    
+    /// back 버튼이 눌렸을 때 호출되는 함수
+    @objc func cancelButtonDidTap(_ sender: UIBarButtonItem) {
+        self.fadeOut()
+        self.navigationController?.popToRootViewController(animated: false)
+    }
+    
+    /// next 버튼이 눌렸을 때 호출되는 함수
+    @objc func nextButtonDidTap(_ sender: UIBarButtonItem) {
+        guard let text = self.newBottleNameView.textField.text
+        else { return }
+        
+        if text.isEmpty {
+            HapticManager.instance.notification(type: .error)
+            self.newBottleNameView.warningLabel.isHidden = false
+            self.newBottleNameView.warningLabel.fadeIn()
+        } else {
+            self.newBottleNameView.textField.endEditing(true)
+            // TODO: - 다음 viewController로 이동
+        }
+    }
+    
+    /// 텍스트필드 내용이 변경됐을 때 호출되는 함수
+    /// 텍스트필드에 텍스트가 있는지 없는지 판별
+    @objc func textFieldDidChange(_ textField: UITextField) {
+        guard let text = textField.text
+        else { return }
+
+        if text.isEmpty {
+            self.navigationItem.rightBarButtonItem?.isEnabled = false
+            self.newBottleNameView.warningLabel.isHidden = false
+            self.newBottleNameView.warningLabel.fadeIn()
+        } else {
+            self.navigationItem.rightBarButtonItem?.isEnabled = true
+            self.newBottleNameView.warningLabel.isHidden = true
+            self.newBottleNameView.warningLabel.fadeOut()
+        }
+    }
+    
+    
+    // MARK: - configurations
+    
+    /// 내비게이션 바의 왼쪽, 오른쪽 버튼 아이템 설정
+    private func configureNavigationItems() {
+        let cancel = UIBarButtonItem(
+            image: AssetImage.xmark,
+            style: .plain,
+            target: self,
+            action: #selector(cancelButtonDidTap)
+        )
+        let next = UIBarButtonItem(
+            image: AssetImage.next,
+            style: .plain,
+            target: self,
+            action: #selector(nextButtonDidTap)
+        )
+        
+        self.navigationItem.leftBarButtonItem = cancel
+        self.navigationItem.rightBarButtonItem = next
+        self.navigationItem.title = Text.navigationBarTitle
+    }
+    
+    /// 텍스트필드 설정
+    private func configureTextField() {
+        self.newBottleNameView.textField.delegate = self
+        self.newBottleNameView.textField.becomeFirstResponder()
+        self.newBottleNameView.textField.addTarget(
+            self,
+            action: #selector(self.textFieldDidChange(_:)),
+            for: .editingChanged
+        )
+    }
+}
+
+extension NewBottleNameViewController: DataProvider {
+    
+    /// 유리병 데이터에 delegate를 통해 받아온 데이터를 대입해주는 함수
+    func send(_ data: NewBottle) {
+        self.bottleData = data
+        self.newBottleNameView.textField.becomeFirstResponder()
+    }
+}
+
+extension NewBottleNameViewController: UITextFieldDelegate {
+    
+    func textFieldDidEndEditing(_ textField: UITextField) {
+        guard let text = textField.text,
+              text.count > Metric.maxLength
+        else { return }
+        
+        textField.text = String(text.prefix(Metric.maxLength))
+        self.newBottleNameView.textField.resignFirstResponder()
+    }
+    
+    /// 리턴 키를 눌렀을 때 자동으로 다음 뷰로 넘어가며, 텍스트필드의 firstResponder 해제
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        if let text = self.newBottleNameView.textField.text,
+           !text.isEmpty {
+            textField.endEditing(true)
+            self.performSegue(
+                withIdentifier: SegueIdentifier.presentNewBottleDatePicker,
+                sender: nil
+            )
+            return true
+        } else {
+            HapticManager.instance.notification(type: .warning)
+            self.newBottleNameView.warningLabel.isHidden = false
+            self.newBottleNameView.warningLabel.fadeIn()
+        }
+        return false
+    }
+    
+    /// 최대 글자수 10자 제한
+    func textField(
+        _ textField: UITextField,
+        shouldChangeCharactersIn range: NSRange,
+        replacementString string: String
+    ) -> Bool {
+        
+        // 텍스트가 유효한지, 편집한 범위를 찾을 수 있는 지 확인
+        guard let currentText = textField.text,
+              Range(range, in: currentText) != nil
+        else { return false }
+        
+        let maxLength = Metric.maxLength + 1
+
+        let updatedTextLength = currentText.count - range.length + string.count
+        let trimLength = updatedTextLength - maxLength
+
+        guard updatedTextLength > maxLength,
+              string.count >= trimLength
+        else { return true }
+        
+        // 새로 입력된 문자열의 초과분을 삭제
+        let index = string.index(string.endIndex, offsetBy: -trimLength)
+        let trimmedReplacementText = string[..<index]
+        
+        guard let startPosition = textField.position(
+            from: textField.beginningOfDocument,
+            offset: range.location
+        ),
+              let endPosition = textField.position(
+                from: textField.beginningOfDocument,
+                offset: NSMaxRange(range)
+              ),
+              let textRange = textField.textRange(
+                from: startPosition,
+                to: endPosition
+              )
+        else { return false }
+              
+        textField.replace(textRange, withText: String(trimmedReplacementText))
+        
+        return false
+    }
+}
+
+extension NewBottleNameViewController {
+    enum Metric {
+        /// 새 저금통 생성시 설정하는 이름의 최대 글자수(10자)
+        static let maxLength: Int = 10
+    }
+    
+    enum Text {
+        /// 내비게이션 바 타이틀
+        static let navigationBarTitle: String = "개인 저금통 만들기"
     }
 }

--- a/Happiggy-bank/Happiggy-bank/HomeTab/NewBottle/UI/View/NewBottleDateView.swift
+++ b/Happiggy-bank/Happiggy-bank/HomeTab/NewBottle/UI/View/NewBottleDateView.swift
@@ -1,0 +1,91 @@
+//
+//  NewBottleDateView.swift
+//  Happiggy-bank
+//
+//  Created by 권은빈 on 2023/02/07.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+class NewBottleDateView: UIView {
+    
+    // MARK: - Properties
+    
+    lazy var mainLabel: BaseLabel = BaseLabel().then {
+        $0.text = Text.mainLabel
+        $0.textColor = AssetColor.mainYellow
+        $0.changeFontSize(to: FontSize.body2)
+    }
+    
+    lazy var descriptionLabel: BaseLabel = BaseLabel().then {
+        $0.text = Text.descriptionLabel
+        $0.textColor = AssetColor.mainGreen
+        $0.changeFontSize(to: FontSize.body4)
+    }
+    
+    lazy var pickerView: UIPickerView = UIPickerView()
+
+    
+    // MARK: - override functions
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        self.backgroundColor = AssetColor.subGrayBG
+        configureSubviewsLayout()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    
+    // MARK: - configuration functions
+    
+    private func configureSubviewsLayout() {
+        self.addSubviews([
+            self.mainLabel,
+            self.descriptionLabel,
+            self.pickerView
+        ])
+        
+        self.pickerView.snp.makeConstraints { make in
+            make.center.equalToSuperview()
+        }
+        
+        self.mainLabel.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.top.equalToSuperview().offset(Metric.mainLabelTop)
+        }
+        
+        self.descriptionLabel.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.top.equalTo(pickerView.snp.bottom).offset(Metric.descriptionLabelTop)
+        }
+    }
+}
+
+extension NewBottleDateView {
+    
+    enum Text {
+        
+        static let mainLabel: String = "저금통 기간을 선택해주세요"
+        
+        static let descriptionLabel: String = "개봉일: yyyy년 mm월 dd일"
+    }
+    
+    enum Metric {
+        
+        static let mainLabelTop: CGFloat = UIScreen.main.bounds.height * mainLabelTopRatio
+        
+        static let descriptionLabelTop: CGFloat = 40
+        
+        static let pickerViewTop: CGFloat = 40
+        
+        static private let mainLabelTopRatio: CGFloat = 220 / 852
+    }
+}

--- a/Happiggy-bank/Happiggy-bank/HomeTab/NewBottle/UI/View/NewBottleMessageView.swift
+++ b/Happiggy-bank/Happiggy-bank/HomeTab/NewBottle/UI/View/NewBottleMessageView.swift
@@ -1,0 +1,20 @@
+//
+//  NewBottleMessageView.swift
+//  Happiggy-bank
+//
+//  Created by 권은빈 on 2023/02/08.
+//
+
+import UIKit
+
+class NewBottleMessageView: UIView {
+
+    /*
+    // Only override draw() if you perform custom drawing.
+    // An empty implementation adversely affects performance during animation.
+    override func draw(_ rect: CGRect) {
+        // Drawing code
+    }
+    */
+
+}

--- a/Happiggy-bank/Happiggy-bank/HomeTab/NewBottle/UI/View/NewBottleMessageView.swift
+++ b/Happiggy-bank/Happiggy-bank/HomeTab/NewBottle/UI/View/NewBottleMessageView.swift
@@ -7,14 +7,107 @@
 
 import UIKit
 
+import SnapKit
+import Then
+
 class NewBottleMessageView: UIView {
-
-    /*
-    // Only override draw() if you perform custom drawing.
-    // An empty implementation adversely affects performance during animation.
-    override func draw(_ rect: CGRect) {
-        // Drawing code
+    
+    // MARK: - Properties
+    
+    /// 메인 라벨(저금통 개봉할 때의 나에게 해줄 한마디를 적어주세요)
+    lazy var mainLabel: BaseLabel = BaseLabel().then {
+        $0.text = Text.mainLabel
+        $0.textColor = AssetColor.mainYellow
+        $0.changeFontSize(to: FontSize.body2)
+        $0.numberOfLines = 2
+        $0.textAlignment = .center
     }
-    */
+    
+    /// 설명 라벨(최대 15자까지 입력 가능합니다)
+    lazy var descriptionLabel: BaseLabel = BaseLabel().then {
+        $0.text = Text.descriptionLabel
+        $0.textColor = AssetColor.subBrown02
+        $0.changeFontSize(to: FontSize.body4)
+    }
+    
+    /// 저금통 개봉 한마디 입력할 텍스트필드
+    lazy var textField: BaseTextField = BaseTextField().then {
+        $0.placeholder = Text.placeholder
+        $0.layer.cornerRadius = Metric.cornerRadius
+        $0.backgroundColor = .white
+        $0.textAlignment = .center
+    }
+    
+    
+    // MARK: - override functions
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        self.backgroundColor = AssetColor.subGrayBG
+        configureSubviewsLayout()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    
+    // MARK: - configurations
+    
+    /// 뷰의 자식 뷰들 레이아웃 설정
+    private func configureSubviewsLayout() {
+        self.addSubviews([
+            self.mainLabel,
+            self.descriptionLabel,
+            self.textField
+        ])
+        
+        self.mainLabel.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.top.equalToSuperview().offset(Metric.mainLabelTop)
+        }
+        
+        self.textField.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.top.equalTo(self.mainLabel.snp.bottom).offset(Metric.textFieldTop)
+            make.height.equalTo(Metric.textFieldHeight)
+            make.width.equalTo(self.textField.snp.height).multipliedBy(Metric.textFieldRatio)
+        }
+        
+        self.descriptionLabel.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.top.equalTo(self.textField.snp.bottom).offset(Metric.descriptionLabelTop)
+        }
+    }
+}
 
+extension NewBottleMessageView {
+    
+    enum Text {
+        
+        static let mainLabel: String = "저금통 개봉할 때의\n나에게 해줄 한마디를 적어주세요"
+        
+        static let descriptionLabel: String = "최대 15자까지 입력 가능합니다"
+        
+        static let placeholder: String = "반가워 내 행복들아!"
+    }
+    
+    enum Metric {
+        
+        static let cornerRadius: CGFloat = 7
+        
+        static let mainLabelTop: CGFloat = UIScreen.main.bounds.height * mainLabelTopRatio
+        
+        static let textFieldTop: CGFloat = 32
+        
+        static let descriptionLabelTop: CGFloat = 16
+        
+        static let textFieldHeight: CGFloat = 56
+        
+        static let textFieldRatio: CGFloat = 311 / 56
+        
+        static private let mainLabelTopRatio: CGFloat = 220 / 852
+    }
 }

--- a/Happiggy-bank/Happiggy-bank/HomeTab/NewBottle/UI/View/NewBottleNameView.swift
+++ b/Happiggy-bank/Happiggy-bank/HomeTab/NewBottle/UI/View/NewBottleNameView.swift
@@ -1,0 +1,126 @@
+//
+//  NewBottleNameView.swift
+//  Happiggy-bank
+//
+//  Created by 권은빈 on 2023/02/06.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class NewBottleNameView: UIView {
+
+    // MARK: - Properties
+    
+    /// 메인 라벨(저금통을 입력해주세요)
+    lazy var mainLabel: BaseLabel = BaseLabel().then {
+        $0.text = Text.mainLabel
+        $0.textColor = AssetColor.mainYellow
+        $0.changeFontSize(to: FontSize.body2)
+    }
+    
+    /// 설명 라벨(저금통은 나중에 변경할 수 있습니다)
+    lazy var descriptionLabel: BaseLabel = BaseLabel().then {
+        $0.text = Text.descriptionLabel
+        $0.textColor = AssetColor.subBrown02
+        $0.changeFontSize(to: FontSize.body4)
+    }
+    
+    /// 경고 라벨(저금통 이름이 없어요!)
+    lazy var warningLabel: BaseLabel = BaseLabel().then {
+        $0.text = Text.warningLabel
+        $0.textColor = AssetColor.etcAlert
+        $0.changeFontSize(to: FontSize.body4)
+        $0.isHidden = true
+    }
+    
+    /// 저금통 이름 입력할 텍스트필드
+    lazy var textField: BaseTextField = BaseTextField().then {
+        $0.placeholder = Text.placeholder
+        $0.layer.cornerRadius = Metric.cornerRadius
+        $0.backgroundColor = .white
+        $0.textAlignment = .center
+    }
+    
+    
+    // MARK: - override functions
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        self.backgroundColor = AssetColor.subGrayBG
+        configureSubviewsLayout()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    
+    // MARK: - configurations
+    
+    /// 뷰의 자식 뷰들 레이아웃 설정
+    private func configureSubviewsLayout() {
+        self.addSubviews([
+            self.mainLabel,
+            self.descriptionLabel,
+            self.warningLabel,
+            self.textField
+        ])
+        
+        self.mainLabel.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.top.equalToSuperview().offset(Metric.mainLabelTop)
+        }
+        
+        self.textField.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.top.equalTo(self.mainLabel.snp.bottom).offset(Metric.textFieldTop)
+            make.height.equalTo(Metric.textFieldHeight)
+            make.width.equalTo(self.textField.snp.height).multipliedBy(Metric.textFieldRatio)
+        }
+        
+        self.descriptionLabel.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.top.equalTo(self.textField.snp.bottom).offset(Metric.descriptionLabelTop)
+        }
+        
+        self.warningLabel.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.top.equalTo(self.descriptionLabel.snp.bottom).offset(Metric.warningLabelTop)
+        }
+    }
+}
+
+extension NewBottleNameView {
+    enum Text {
+        static let mainLabel: String = "저금통 이름을 입력해주세요"
+        
+        static let descriptionLabel: String = "저금통 이름은 나중에 변경할 수 있습니다"
+        
+        static let warningLabel: String = "저금통 이름이 없어요!"
+        
+        static let placeholder: String = "최대 15자까지 가능합니다"
+    }
+    
+    enum Metric {
+        static let cornerRadius: CGFloat = 7
+        
+        static let mainLabelTop: CGFloat = UIScreen.main.bounds.height * mainLabelTopRatio
+        
+        static let textFieldTop: CGFloat = 32
+        
+        static let descriptionLabelTop: CGFloat = 16
+        
+        static let warningLabelTop: CGFloat = 16
+        
+        static let textFieldHeight: CGFloat = 56
+        
+        static let textFieldRatio: CGFloat = 311 / 56
+        
+        static private let mainLabelTopRatio: CGFloat = 220 / 852
+    }
+}

--- a/Happiggy-bank/Happiggy-bank/HomeTab/NewBottle/UI/View/NewBottleNameView.swift
+++ b/Happiggy-bank/Happiggy-bank/HomeTab/NewBottle/UI/View/NewBottleNameView.swift
@@ -103,7 +103,7 @@ extension NewBottleNameView {
         
         static let warningLabel: String = "저금통 이름이 없어요!"
         
-        static let placeholder: String = "최대 15자까지 가능합니다"
+        static let placeholder: String = "최대 10자까지 가능합니다"
     }
     
     enum Metric {

--- a/Happiggy-bank/Happiggy-bank/Utils/Extensions/CATransition+PopupAnimation.swift
+++ b/Happiggy-bank/Happiggy-bank/Utils/Extensions/CATransition+PopupAnimation.swift
@@ -9,7 +9,7 @@ import UIKit
 
 extension CATransition {
     
-    /// 뷰가 사라질 때 페이드 아웃 효과를 나타냄
+    /// 뷰가 사라질 때 페이드 인/아웃 효과를 나타냄
     static func fadeTransition() -> CATransition {
         let transition = CATransition()
         transition.duration = self.transitionDuration

--- a/Happiggy-bank/Happiggy-bank/Utils/Extensions/UINavigationController+transition.swift
+++ b/Happiggy-bank/Happiggy-bank/Utils/Extensions/UINavigationController+transition.swift
@@ -1,0 +1,33 @@
+//
+//  UINavigationController+transition.swift
+//  Happiggy-bank
+//
+//  Created by 권은빈 on 2023/02/08.
+//
+
+import UIKit
+
+extension UINavigationController {
+    
+    /// fadeout 효과 적용된 상태로 뷰 컨트롤러 pop
+    @discardableResult
+    func popViewControllerWithFade() -> UIViewController? {
+        self.fadeOut()
+        return self.popViewController(animated: false)
+    }
+    
+    /// fadeout 효과 적용된 상태로 루트 뷰로 pop
+    @discardableResult
+    func popToRootViewControllerWithFade() -> [UIViewController]? {
+        self.fadeOut()
+        return self.popToRootViewController(animated: false)
+    }
+    
+    /// fadein 효과 적용된 상태로 뷰 컨트롤러 push
+    /// - Parameters:
+    ///    - to: push할 뷰 컨트롤러
+    func pushViewControllerWithFade(to viewController: UIViewController) {
+        self.fadeIn()
+        self.pushViewController(viewController, animated: false)
+    }
+}

--- a/Happiggy-bank/Happiggy-bank/Utils/Extensions/UIViewController/UIViewController+FadeInOut.swift
+++ b/Happiggy-bank/Happiggy-bank/Utils/Extensions/UIViewController/UIViewController+FadeInOut.swift
@@ -1,5 +1,5 @@
 //
-//  UIViewController+FadeOut.swift
+//  UIViewController+FadeInOut.swift
 //  Happiggy-bank
 //
 //  Created by sun on 2022/03/10.
@@ -8,6 +8,14 @@
 import UIKit
 
 extension UIViewController {
+    
+    /// 뷰가 나타날 때 페이드인 효과를 주기 위한 syntactic sugar
+    func fadeIn() {
+        guard let window = self.view.window
+        else { return }
+        
+        window.layer.add(CATransition.fadeTransition(), forKey: kCATransition)
+    }
     
     /// 뷰가 사라질 때 페이드아웃 효과를 주기 위한 syntactic sugar
     func fadeOut() {

--- a/Happiggy-bank/Happiggy-bank/Utils/Protocol/DataProvider.swift
+++ b/Happiggy-bank/Happiggy-bank/Utils/Protocol/DataProvider.swift
@@ -10,6 +10,19 @@ import Foundation
 /// 뷰 컨트롤러간 데이터 전송을 위한 Delegate
 protocol DataProvider {
     
+    // TODO: 리팩토링 완료시 삭제하기
     /// 새 유리병 데이터를 전송하는 함수
     func sendNewBottleData(_ data: NewBottle)
+    
+    /// 새 유리병 데이터를 전송하는 함수
+    func send(_ data: NewBottle)
+}
+
+// Optional Protocol을 위한 정의
+// @objc protocol을 사용해 정의하는 것이 Swift 가이드에 나와있는대로지만 NewBottle 타입이 objective-C로 번역이 안돼 대안 사용
+extension DataProvider {
+    
+    func sendNewBottleData(_ data: NewBottle) { }
+    
+    func send(_ data: NewBottle) { }
 }


### PR DESCRIPTION
## 관련 내용

resolves #284 

### HomeTabViewController
- navigationController 관련 코드 수정

### UINavigationController
- fade in/out 적용된 push, pop 메서드 extension으로 생성

### 기타
- NewBottleName
  - UI 코드로 생성
  - Controller 생성(원래 NewBottleNameFieldViewController)
- NewBottleDate
  - UI 코드로 생성
  - Controller 생성(원래 NewBottleDatePickerViewController)
  - Ver2에서 완전 바뀔 예정이라서 리팩토링 따로 안 함. viewModel도 원래 있던 컨트롤러에서 생성한 것 그대로 썼습니다.
- NewBottleMessage
  - UI 코드로 생성
  - Controller 생성(원래 NewBottleMessageFieldViewController)

### CoreData
- fetchedResultsController는 한번에 작업할 예정입니다. 여기 관련 코드 없어요!
- 그래서 NewBottleMessageController에 `save`하는 부분이 리팩토링이 덜 됐습니닷.


=> **그 바이러스때문에 많이 힘드시겠지만 UI 관련 코드이니만큼 금방 확인 해 주시면 코어데이터 관련 작업을 바로 들어갈 수 있을 것 같아용**(물론 브랜치 따서 해도 됩니다 그저 컨플릭트가 아주많이 날 것 같아서 두려울 뿐...이므로 아 몰라 배째 하셔도 됨 ㅎ)