### PR TITLE
[feat] 탭바 컨트롤러, 네비게이션 컨트롤러 디자인 반영 및 목데이터 추가  #286 #287 #288 

### DIFF
--- a/Happiggy-bank/Happiggy-bank/Base/Model/Bottle+CoreDataClass.swift
+++ b/Happiggy-bank/Happiggy-bank/Base/Model/Bottle+CoreDataClass.swift
@@ -156,16 +156,77 @@ public class Bottle: NSManagedObject {
 }
 
 // TODO: 목데이터 - 추후 삭제
+
+enum FooBottleDuration: Int, CaseIterable {
+    case week = 7
+    case month = 30
+    case threeMonths = 90
+    case halfYear = 180
+    case year = 365
+}
+
 extension Bottle {
-    
-    // swiftlint:disable line_length
-    private static func nthDayFromToday(_ value: Int) -> Date {
-        Calendar.current.date(byAdding: .day, value: value, to: Date())!
+
+    /// 모든 기간 저금통 배열
+    static let fooOpenBottles = FooBottleDuration.allCases
+        .shuffled()
+        .enumerated()
+        .map { fooOpened(duration: $0.element, openedNdaysBefore: UInt8($0.offset)) }
+
+    /// 인자를 별도로 설정하지 않으면 하루 전이 종료일이었던 1년 짜리 저금통 리턴
+    static func fooOpened(duration: FooBottleDuration = .year, openedNdaysBefore: UInt8 = 1) -> Bottle {
+        let daysPassed = Int(openedNdaysBefore) + duration.rawValue
+        let startDate = nthDayFromDate(value: -daysPassed)
+        let endDate = Calendar.current.startOfDay(for: nthDayFromDate(startDate, value: duration.rawValue))
+
+        let bottle = Bottle(
+            title: "\(duration.rawValue) 가짜냠냠이🥸",
+            startDate: startDate,
+            endDate: endDate,
+            message: "축 가짜 냠냠이 개봉🎉"
+        )
+        bottle.isOpen = true
+
+        for index in 0..<duration.rawValue {
+            Note.createRandomNote(for: bottle, date: nthDayFromDate(startDate, value: index))
+        }
+
+        return bottle
     }
+
+    /// 인자를 별도로 설정하지 않으면 종료까지 이틀 남은 1년 짜리 저금통 리턴
+    static func fooInProgress(duration: FooBottleDuration = .year, daysLeft: UInt8 = 2) -> Bottle {
+        let daysLeft = 0..<duration.rawValue ~= Int(daysLeft) ? Int(daysLeft) : 2
+        let daysPassed = duration.rawValue - daysLeft
+        let startDate = nthDayFromDate(value: -daysPassed)
+        let endDate = Calendar.current.startOfDay(for: nthDayFromDate(startDate, value: duration.rawValue))
+
+        let bottle = Bottle(
+            title: "가짜냠냠이🥸",
+            startDate: startDate,
+            endDate: endDate,
+            message: "축 가짜 냠냠이 개봉🎉"
+        )
+
+        for index in 0..<daysPassed {
+            Note.createRandomNote(for: bottle, date: nthDayFromDate(startDate, value: index))
+        }
+
+        return bottle
+    }
+
+    private static func nthDayFromDate(_ date: Date = Date(), value: Int) -> Date {
+        Calendar.current.date(byAdding: .day, value: value, to: date)!
+    }
+
+
+    // MARK: - Old Version
+
+    // swiftlint:disable line_length
     
     private static func makeMockData(duration: Int, isOpen: Bool = true) -> Bottle {
-        let startDate = nthDayFromToday(-duration)
-        let endDate = nthDayFromToday(-1)
+        let startDate = nthDayFromDate(value: -duration)
+        let endDate = nthDayFromDate(value: -1)
         
         let bottle = Bottle(
             title: "행복냠냠이",
@@ -184,7 +245,7 @@ extension Bottle {
         for index in -count..<0 {
             Note.create(
                 id: UUID(),
-                date: nthDayFromToday(index),
+                date: nthDayFromDate(value: index),
                 color: NoteColor.allCases.randomElement()!,
                 content:
                     "일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십",
@@ -192,37 +253,27 @@ extension Bottle {
             )
         }
     }
-    
-    static let fooOpenBottles: [Bottle] = {
-        var bottles = [Bottle]()
-        
-        for duration in [365, 90, 60, 30, 7] {
-            bottles.append(makeMockData(duration: duration))
-        }
-        
-        return bottles
-    }()
-    
+
     /// 테스트용 목 데이터
     static let foo: Bottle = {
         let count = 300
-        let startDate = nthDayFromToday(-count)
-        let endDate = nthDayFromToday(5)
+        let startDate = nthDayFromDate(value: -count)
+        let endDate = nthDayFromDate(value: 5)
 //        let endDate = nthDayFromToday(10)
         
         let bottle = Bottle(title: "행복냠냠이", startDate: startDate, endDate: endDate, message: "마지막멘트")
         
         // swiftlint:disable line_length
         Note.create(id: UUID(), date: startDate, color: NoteColor.green, content: "시작!", bottle: bottle)
-        Note.create(id: UUID(), date: nthDayFromToday(-9), color: NoteColor.pink, content: "일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십", bottle: bottle)
-        Note.create(id: UUID(), date: nthDayFromToday(-3), color: NoteColor.white, content: "100자 좀 적은가? 근데 괜찮은 것 같기도 하고...늘리기는 또 귀찮은데...", bottle: bottle)
-        Note.create(id: UUID(), date: nthDayFromToday(-8), color: NoteColor.purple, content: "왜냐면 한줄만 쓰는 날도 백퍼 있을 것이기 때문", bottle: bottle)
-        Note.create(id: UUID(), date: nthDayFromToday(-1), color: NoteColor.yellow, content: "졸리다 졸려 졸려", bottle: bottle)
-        Note.create(id: UUID(), date: nthDayFromToday(0), color: NoteColor.yellow, content: "누가 뚝딱 만들어주면 좋겠다 한 3줄 정도까지 채우고 싶은데 아무거나 써보기 이모지도 써보기 시험 시험 테스트 ☀️", bottle: bottle)
+        Note.create(id: UUID(), date: nthDayFromDate(value: -9), color: NoteColor.pink, content: "일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십", bottle: bottle)
+        Note.create(id: UUID(), date: nthDayFromDate(value: -3), color: NoteColor.white, content: "100자 좀 적은가? 근데 괜찮은 것 같기도 하고...늘리기는 또 귀찮은데...", bottle: bottle)
+        Note.create(id: UUID(), date: nthDayFromDate(value: -8), color: NoteColor.purple, content: "왜냐면 한줄만 쓰는 날도 백퍼 있을 것이기 때문", bottle: bottle)
+        Note.create(id: UUID(), date: nthDayFromDate(value: -1), color: NoteColor.yellow, content: "졸리다 졸려 졸려", bottle: bottle)
+        Note.create(id: UUID(), date: nthDayFromDate(value: 0), color: NoteColor.yellow, content: "누가 뚝딱 만들어주면 좋겠다 한 3줄 정도까지 채우고 싶은데 아무거나 써보기 이모지도 써보기 시험 시험 테스트 ☀️", bottle: bottle)
         for index in (10-count)..<(-10) {
             let note = Note.create(
                 id: UUID(),
-                date: nthDayFromToday(index),
+                date: nthDayFromDate(value: index),
                 color: NoteColor.allCases.randomElement()!,
                 content: "일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십",
                 bottle: bottle)

--- a/Happiggy-bank/Happiggy-bank/Base/Model/Note+CoreDataClass.swift
+++ b/Happiggy-bank/Happiggy-bank/Base/Model/Note+CoreDataClass.swift
@@ -112,3 +112,121 @@ public class Note: NSManagedObject {
         return firstWord
     }()
 }
+
+// MARK: - Mock Data
+
+extension Note {
+
+    private static let lyrics = { """
+    🍎
+    I'm standing on the edge 🙌
+    난 가장 높은 곳에서 123
+    456 Everything is upside down
+    ☺️ 두렵지 않아 break it down
+    당당히 서 있어 ✅ with my toes
+    Everybody listen up now
+    No 더 이상은 no turnin' back
+    No turnin' 🔥back, no turnin' back
+    789 No, don't be scared
+    003 아슬하게, 아찔하게 ˊ°̮ˋ
+    두 손을 펼쳐 12329 up in the air
+    Up in the air☀️, up in the air
+    망설이지 마, 뭐 어때? (‘∀`)ゝ”
+    When I move (  ¯⌓¯)
+    너의 body를 흔들어봐 🤬 when I move
+    When I move ~!@!)(
+    더 자유롭게 breakin' all the rules
+    When I 🤬 moveXD
+    리듬에 맡겨 느낀 그대로 🥬
+    이런 move 나의 move $%#^@$
+    Oh, when I move:(
+    Oh, whats the problem? ː̗̀(ꙨꙨ)ː̖́
+    점점 빠져드는 123~~~ 이 공간의 flow
+    나조차도 어림잡지 못해 out of my control
+    홀린 듯 몸을 맡겨, 이 끌림이 싫진 않잖아
+    그치? 🎉 나를 따라 너를 던져봐 (너를 던져봐)
+    No 더 이상은 no 10^^ turnin' back
+    No turnin' back, no turnin' back
+    No, don't be scared:)
+    아슬하게,✿◕ ‿ ◕✿ 아찔하게
+    두 손을 펼쳐 up in the air 🥳
+    Up in the air, up in the air
+    ヽ(ﾟДﾟ)ﾉ 망설이지 마 we just dance~~~
+    When I move📱
+    너의 body를 흔들어봐 when I move
+    When I move ʕ•ᴥ•ʔ
+    더 자유롭게 breakin' all the rules
+    When I move!!#$%^&*()_+~
+    리듬에 맡겨 느낀 그대로
+    이런 ❁_❁ move 나의 move
+    Oh, when ✉️ I move
+    다시 move again 109238
+    We 1231waited for this time
+    아찔하게 흔들어 roller coaster ride
+    😃아스팔트에서 피운 꽃 strong survive
+    ≧◡≦ 춤춰봐, 더 자유롭게 미쳐봐
+    Shake your body, bounce your body
+    왔어 우리에게 너무 좋은 날이 (날이)
+    Move your body 들려, 내 말이?
+    너가 원했던 이 순간이🍎☺️🧐💤👏
+    멈추지 마, 계속 on my way
+    I'll never look back oh, baby
+    움츠렸던 마음을 녹여, 어제의 너를 잊어
+    Moving (๑°ㅁ°๑)‼✧ on baby 셣
+    When I (ง︡'-'︠)ง (move)
+    너의 body를 🫥흔들어봐 when I move
+    When I move (and I move, and I move)
+    더 자유롭게 🧚‍♀️ breakin' all the rules
+    When I (〃⌒▽⌒〃)ゝ move fJDAF
+    ( °࿁° ) 리듬에 맡겨 느낀 그대로 뷁
+    이런 move 🧶 나의 move $#@$*
+    Oh, when 🐱 I move
+    When I move !@FDSfhi
+    😎 끝까지 손을 뻗어 when I move
+    When I move 그래~~~욜ㅇ뛣
+    We goin' higher breakin' all the rules
+    Watch 🧐me move
+    널 사로잡은 우리만의 move ( ͡❛ ͜ʖ ͡❛)
+    When I move, when I move
+    Oh, when I move 띠용 🥰
+    """
+        .split(separator: "\n")
+        .map { String($0) } + Array(repeating: "\n", count: 10)
+    }()
+
+    /// 인자를 별도로 설정하지 않으면 오늘 날짜의 3줄 짜리 사진이 있는 노랑 쪽지 리턴
+    @discardableResult
+    static func createMockNote(
+        for bottle: Bottle,
+        date: Date,
+        numberOfLines: Int = 3,
+        hasPhoto: Bool = true,
+        color: NoteColor = .yellow
+    ) -> Note {
+        let imageURL = hasPhoto ? "someURL" : nil
+        let numberOfLines = 1...20 ~= numberOfLines ? numberOfLines : 1
+        let lyrics = lyrics.shuffled()
+        let content = (0..<numberOfLines).map { lyrics[$0] }
+
+        return Note.create(
+            id: UUID(),
+            date: date,
+            color: color,
+            content: content.joined(separator: "\n"),
+            imageURL: imageURL,
+            bottle: bottle
+        )
+    }
+
+    /// 줄 수와 색상과 사진 여부가 랜덤이 쪽지 리턴
+    @discardableResult
+    static func createRandomNote(for bottle: Bottle, date: Date) -> Note {
+        createMockNote(
+            for: bottle,
+            date: date,
+            numberOfLines: (1...20).randomElement()!,
+            hasPhoto: [true, false].randomElement()!,
+            color: NoteColor.allCases.randomElement()!
+        )
+    }
+}

--- a/Happiggy-bank/Happiggy-bank/Base/UI/Controller/CustomNavigationController.swift
+++ b/Happiggy-bank/Happiggy-bank/Base/UI/Controller/CustomNavigationController.swift
@@ -23,6 +23,7 @@ final class CustomNavigationController: UINavigationController {
         self.fontManager = fontManager
 
         super.init(rootViewController: rootViewController)
+        self.view.backgroundColor = .systemBackground
     }
 
     @available(*, unavailable)
@@ -36,11 +37,23 @@ final class CustomNavigationController: UINavigationController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        self.configureNavigationBar()
         self.subscribeToFontPublisher()
     }
 
 
     // MARK: - Functions
+
+    private func configureNavigationBar() {
+        self.navigationBar.standardAppearance = self.navigationBar.standardAppearance.then {
+            $0.shadowColor = .clear
+            $0.backgroundEffect = .none
+            $0.backgroundColor = .systemBackground
+
+            // FIXME: 정렬이 이상함...
+            $0.setBackIndicatorImage(AssetImage.back, transitionMaskImage: AssetImage.back)
+        }
+    }
 
     private func subscribeToFontPublisher() {
         self.cancellable = fontManager.fontPublisher
@@ -54,6 +67,9 @@ final class CustomNavigationController: UINavigationController {
             return
         }
 
-        self.navigationBar.titleTextAttributes = [.font: font]
+        self.navigationBar.standardAppearance = self.navigationBar.standardAppearance.then {
+            $0.titleTextAttributes = [.font: font]
+            $0.largeTitleTextAttributes = [.font: font]
+        }
     }
 }

--- a/Happiggy-bank/Happiggy-bank/Base/UI/Controller/CustomTabBarController.swift
+++ b/Happiggy-bank/Happiggy-bank/Base/UI/Controller/CustomTabBarController.swift
@@ -32,32 +32,48 @@ final class CustomTabBarController: UITabBarController {
         fatalError("init(coder:) has not been implemented")
     }
 
-    
+
     // MARK: - Life cycle
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         self.configureTabBar()
     }
 
-    
+
     // MARK: - Functions
-    
+
     /// 탭 바 초기 설정
     private func configureTabBar() {
         self.configureBasicSettings()
         self.subscribeToFontPublisher()
         self.setNavigationControllers()
     }
-    
+
     /// 탭 바 기본 설정
     private func configureBasicSettings() {
         object_setClass(self.tabBar, CustomTabBar.self)
         self.view.backgroundColor = .systemBackground
         self.tabBar.backgroundColor = .systemBackground
         self.tabBar.isTranslucent = false
+        self.tabBar.standardAppearance = self.tabBar.standardAppearance.then {
+            $0.shadowColor = .clear
+            $0.backgroundEffect = .none
+        }
+        self.configureDivider()
     }
+
+    /// 탭 바 상단에 경계선 생성
+    private func configureDivider() {
+        let dividerView = UIView().then { $0.backgroundColor = AssetColor.subGrayBG }
+        self.tabBar.addSubview(dividerView)
+        dividerView.snp.makeConstraints {
+            $0.horizontalEdges.top.equalToSuperview()
+            $0.height.equalTo(CGFloat.one)
+        }
+    }
+
 
     private func subscribeToFontPublisher() {
         self.cancellable = fontManager.fontPublisher
@@ -71,9 +87,12 @@ final class CustomTabBarController: UITabBarController {
             return
         }
 
-        UITabBarItem.appearance().setTitleTextAttributes([.font: font], for: .normal)
+        self.tabBar.standardAppearance = self.tabBar.standardAppearance.then {
+            $0.stackedLayoutAppearance.normal.titleTextAttributes = [.font: font]
+            $0.stackedLayoutAppearance.selected.titleTextAttributes = [.font: font]
+        }
     }
-    
+
     // TODO: - 각 NavigationController에 들어갈 ViewController 수정/교체
     /// 탭 바의 내비게이션 컨트롤러 배열 설정
     private func setNavigationControllers() {
@@ -95,7 +114,7 @@ final class CustomTabBarController: UITabBarController {
             )
         ]
     }
-    
+
     /// 각 내비게이션 컨트롤러 기본 설정
     fileprivate func createNavigationController(
         for rootViewController: UIViewController,
@@ -117,12 +136,12 @@ final class CustomTabBarController: UITabBarController {
 
 
 extension CustomTabBarController {
-    
+
     enum Tab: Int {
         case home
         case list
         case settings
-        
+
         /// 탭 바 아이템 타이틀
         var title: String {
             switch self {
@@ -134,7 +153,7 @@ extension CustomTabBarController {
                 return "환경설정"
             }
         }
-        
+
         /// 탭 바 아이템 이미지
         var image: UIImage? {
             switch self {

--- a/Happiggy-bank/Happiggy-bank/Base/UI/View/CustomTabBar.swift
+++ b/Happiggy-bank/Happiggy-bank/Base/UI/View/CustomTabBar.swift
@@ -30,14 +30,12 @@ final class CustomTabBar: UITabBar {
     override init(frame: CGRect) {
         super.init(frame: frame)
         
-        self.configureDivider()
         self.configureItemPositionsIfNeeded()
     }
     
     required init?(coder: NSCoder) {
         super.init(coder: coder)
-        
-        self.configureDivider()
+
         self.configureItemPositionsIfNeeded()
     }
     
@@ -56,21 +54,7 @@ final class CustomTabBar: UITabBar {
 
     
     // MARK: - Functions
-    
-    /// 상단에 구분선 생성
-    private func configureDivider() {
-        let dividerView = UIView().then {
-            $0.frame = CGRect(
-                x: .zero,
-                y: .zero,
-                width: UIScreen.main.bounds.width,
-                height: .one
-            )
-            $0.backgroundColor = .tabBarDivider
-        }
-        self.addSubview(dividerView)
-    }
-    
+
     /// 탭 아이템 위치 조정
     private func configureItemPositionsIfNeeded() {
         guard UIScreen.main.bounds.height >= Metric.heightCap

--- a/Happiggy-bank/Happiggy-bank/HomeTab/Home/UI/Controller/HomeTabViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/HomeTab/Home/UI/Controller/HomeTabViewController.swift
@@ -115,15 +115,20 @@ final class HomeTabViewController: UIViewController {
         publishedBottle
             .receive(on: DispatchQueue.main)
             .sink { [weak self] bottle in
-                self.viewModel.bottle = bottle
-                self.homeView = HomeView(
-                    title: self.viewModel.bottle?.title,
-                    dDay: self.viewModel.dDay(),
-                    hasNotes: self.viewModel.hasNotes
+                guard let viewModel = self?.viewModel
+                else {
+                    return
+                }
+
+                self?.viewModel.bottle = bottle
+                self?.homeView = HomeView(
+                    title: viewModel.bottle?.title,
+                    dDay: viewModel.dDay(),
+                    hasNotes: viewModel.hasNotes
                 )
-                self.view = self.homeView
-                configureHomeView()
-                configureButton()
+                self?.view = self?.homeView
+                self?.configureHomeView()
+                self?.configureButton()
             }
             .store(in: &cancellableBag)
     }

--- a/Happiggy-bank/Happiggy-bank/ListTab/BotteList/UI/Controller/ListTabViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/ListTab/BotteList/UI/Controller/ListTabViewController.swift
@@ -63,7 +63,7 @@ final class ListTabViewController: UIViewController {
     /// 내비게이션 바 속성 설정
     private func configureNavigationBar() {
         self.navigationController?.navigationBar.tintColor = UIColor.white
-        self.title = StringLiteral.navigationBarTitle
+        self.navigationItem.title = StringLiteral.navigationBarTitle
         self.navigationItem.backButtonTitle = .empty
     }
     


### PR DESCRIPTION
## 관련 이슈

- resolves #286
- resolves #287 
- resolves #288 

<br>

## 작업 내용

해당 PR의 내용을 간단히 한 줄로 작성해주세요.

- 탭바 컨트롤러, 네비게이션바 컨트롤러 UI 디자인을 반영했습니다. 
- 저금통 및 쪽지 목데이터를 추가했습니다. 

### 클래스/메서드/swift 파일 이름 등

- swift 파일 명, 클래스/메서드 이름 등 작업한 상세 내용 간략히 서술해주세요.

**저금통 목데이터**
- `fooOpenBottles`: 모든 기간의 개봉 저금통이 1개씩 담긴 저금통 배열 리턴
-  `fooOpened(duration:openedNdaysBefore)`: 원하는 기간의 N일 전에 개봉된 저금통 리턴
-  `fooInProgress(duration:daysLeft:)`: 원하는 기간의 개봉까지 N일 남은 진행중인 저금통 리턴

<br>

## 리뷰 사항
