### PR TITLE
[refactor] BottleNameEditViewController 리팩토링 #304

### DIFF
--- a/Happiggy-bank/Happiggy-bank.xcodeproj/project.pbxproj
+++ b/Happiggy-bank/Happiggy-bank.xcodeproj/project.pbxproj
@@ -150,6 +150,8 @@
 		A819CF9F27DDD97C00DE8E72 /* HapticManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A819CF9E27DDD97C00DE8E72 /* HapticManager.swift */; };
 		A819CFA127DE034F00DE8E72 /* NewBottle.swift in Sources */ = {isa = PBXBuildFile; fileRef = A819CFA027DE034F00DE8E72 /* NewBottle.swift */; };
 		A824A0B027CE72C000B99E9A /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = A824A0AF27CE72C000B99E9A /* Then */; };
+		A831E4472A56871B00FA92A3 /* BottleNameEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A831E4462A56871B00FA92A3 /* BottleNameEditView.swift */; };
+		A831E4492A56882300FA92A3 /* HomeBottleNameEditViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A831E4482A56882300FA92A3 /* HomeBottleNameEditViewController.swift */; };
 		A83CA2AF2993587300081E07 /* NewBottleMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83CA2AE2993587300081E07 /* NewBottleMessageView.swift */; };
 		A83CA2B1299359DB00081E07 /* NewBottleMessageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83CA2B0299359DB00081E07 /* NewBottleMessageViewController.swift */; };
 		A83CA2B32993669800081E07 /* UINavigationController+transition.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83CA2B22993669800081E07 /* UINavigationController+transition.swift */; };
@@ -330,6 +332,8 @@
 		A81742FE27C108DC0016C921 /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
 		A819CF9E27DDD97C00DE8E72 /* HapticManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HapticManager.swift; sourceTree = "<group>"; };
 		A819CFA027DE034F00DE8E72 /* NewBottle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewBottle.swift; sourceTree = "<group>"; };
+		A831E4462A56871B00FA92A3 /* BottleNameEditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottleNameEditView.swift; sourceTree = "<group>"; };
+		A831E4482A56882300FA92A3 /* HomeBottleNameEditViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeBottleNameEditViewController.swift; sourceTree = "<group>"; };
 		A83CA2AE2993587300081E07 /* NewBottleMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewBottleMessageView.swift; sourceTree = "<group>"; };
 		A83CA2B0299359DB00081E07 /* NewBottleMessageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewBottleMessageViewController.swift; sourceTree = "<group>"; };
 		A83CA2B22993669800081E07 /* UINavigationController+transition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINavigationController+transition.swift"; sourceTree = "<group>"; };
@@ -766,6 +770,7 @@
 				D284A5DD27FF3EFB00D20699 /* BottleNameEditViewController.swift */,
 				A8BD833227BE104900E0DE41 /* HomeViewController.swift */,
 				A81148DF295571A1004A35E7 /* HomeTabViewController.swift */,
+				A831E4482A56882300FA92A3 /* HomeBottleNameEditViewController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -775,6 +780,7 @@
 			children = (
 				A8BD834627BE337900E0DE41 /* HomeView.swift */,
 				A80248242963E58A00F2EA81 /* BottleTitleStack.swift */,
+				A831E4462A56871B00FA92A3 /* BottleNameEditView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -1374,6 +1380,7 @@
 				A81148E0295571A2004A35E7 /* HomeTabViewController.swift in Sources */,
 				A425F8B827EDF59A00A005AB /* TagCell.swift in Sources */,
 				A4B2860F27D9F539008769EB /* NewNoteDatePickerViewModel.swift in Sources */,
+				A831E4492A56882300FA92A3 /* HomeBottleNameEditViewController.swift in Sources */,
 				A85B38862990CE7700ED8C72 /* NewBottleNameView.swift in Sources */,
 				A467B5C827DA258700AC702D /* NewNoteDatePickerRowView.swift in Sources */,
 				A484A3052958945E00A58312 /* BaseTextView.swift in Sources */,
@@ -1511,6 +1518,7 @@
 				A46B10F42814362A004AB185 /* UIView+AllFontUsingSubviews.swift in Sources */,
 				A4C1AFC227E47AD80096CD3E /* String+EmptyString.swift in Sources */,
 				A4C1AFC627E482E10096CD3E /* CGFloat+Values.swift in Sources */,
+				A831E4472A56871B00FA92A3 /* BottleNameEditView.swift in Sources */,
 				A484A3092958953600A58312 /* BaseButton.swift in Sources */,
 				A8BD833F27BE30B400E0DE41 /* Constants.swift in Sources */,
 				A41DE62827F368BF002A7669 /* NoteDetailViewModel.swift in Sources */,

--- a/Happiggy-bank/Happiggy-bank/HomeTab/Home/UI/Controller/HomeBottleNameEditViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/HomeTab/Home/UI/Controller/HomeBottleNameEditViewController.swift
@@ -11,7 +11,7 @@ final class HomeBottleNameEditViewController: UIViewController {
     
     // MARK: - Properties
     
-    var nameEditView = BottleNameEditView()
+    private let nameEditView = BottleNameEditView()
     
     var bottleData: Bottle?
     

--- a/Happiggy-bank/Happiggy-bank/HomeTab/Home/UI/Controller/HomeBottleNameEditViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/HomeTab/Home/UI/Controller/HomeBottleNameEditViewController.swift
@@ -1,0 +1,314 @@
+//
+//  HomeBottleNameEditViewController.swift
+//  Happiggy-bank
+//
+//  Created by 권은빈 on 2023/07/06.
+//
+
+import UIKit
+
+final class HomeBottleNameEditViewController: UIViewController {
+    
+    // MARK: - Properties
+    
+    var nameEditView = BottleNameEditView()
+    
+    var bottleData: Bottle?
+    
+    
+    // MARK: - Life Cycles
+    
+    override func loadView() {
+        self.view = self.nameEditView
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureNavigationItems()
+        configureTextField()
+    }
+    
+    
+    // MARK: - objc functions
+    
+    /// back 버튼이 눌렸을 때 호출되는 함수
+    @objc func cancelButtonDidTap(_ sender: UIBarButtonItem) {
+        self.navigationController?.popToRootViewControllerWithFade()
+    }
+    
+    /// save 버튼이 눌렸을 때 호출되는 함수
+    @objc func saveButtonDidTap(_ sender: UIBarButtonItem) {
+        guard let text = self.nameEditView.textField.text
+        else { return }
+        
+        if text.isEmpty {
+            HapticManager.instance.notification(type: .error)
+            self.nameEditView.warningLabel.isHidden = false
+            self.nameEditView.warningLabel.fadeIn()
+        } else {
+            self.nameEditView.textField.endEditing(true)
+            self.present(self.confirmationAlert(), animated: true)
+        }
+    }
+    
+    /// 텍스트필드 내용이 변경됐을 때 호출되는 함수
+    /// 텍스트필드에 텍스트가 있는지 없는지 판별
+    @objc func textFieldDidChange(_ textField: UITextField) {
+        guard let text = textField.text
+        else { return }
+
+        if text.isEmpty {
+            self.navigationItem.rightBarButtonItem?.isEnabled = false
+            self.nameEditView.warningLabel.isHidden = false
+            self.nameEditView.warningLabel.fadeIn()
+        } else {
+            self.navigationItem.rightBarButtonItem?.isEnabled = true
+            self.nameEditView.warningLabel.isHidden = true
+            self.nameEditView.warningLabel.fadeOut()
+        }
+    }
+    
+  
+    // MARK: - Functions
+    
+    /// 변경한 저금통 이름이 원본과 같은지 체크하는 메서드
+    private func checkIfNameIsChanged() -> Bool {
+        guard let currentBottle = bottleData,
+              let editedName = nameEditView.textField.text
+        else { return false }
+        
+        return currentBottle.title != editedName
+    }
+    
+    /// 새 저금통 저장하는 메서드
+    private func saveBottle() -> Bool {
+        guard let currentBottle = bottleData,
+              let editedName = nameEditView.textField.text
+        else { return false }
+        
+        currentBottle.title = editedName
+        let result = PersistenceStore.shared.save()
+        
+        switch result {
+        case .success:
+            return true
+        case .failure:
+            return false
+        }
+    }
+    
+    /// 생성 확인 알림을 나타냄
+    private func confirmationAlert() -> UIAlertController {
+        
+        let confirmAction = UIAlertAction.confirmAction(
+            title: Text.confirmationAlertConfirmButtonTitle
+        ) { _ in
+            let isNewNameValid = self.checkIfNameIsChanged()
+            
+            guard isNewNameValid == true
+            else {
+                self.present(
+                    self.invalidDataFailureAlert(),
+                    animated: false
+                )
+                return
+            }
+            guard self.saveBottle() == true
+            else {
+                self.present(
+                    self.fetchFailureAlert(),
+                    animated: false
+                )
+                return
+            }
+          
+            self.navigationController?.popToRootViewControllerWithFade()
+        }
+        
+        let cancelAction = UIAlertAction.cancelAction { _ in
+            self.nameEditView.textField.becomeFirstResponder()
+        }
+        
+        return UIAlertController.basic(
+            alertTitle: Text.confirmationAlertTitle,
+            alertMessage: Text.confirmationAlertMessage,
+            confirmAction: confirmAction,
+            cancelAction: cancelAction
+        )
+    }
+    
+    /// 데이터가 조건에 맞지 않을 때 나타나는 알림
+    private func invalidDataFailureAlert() -> UIAlertController {
+        let cancelAction = UIAlertAction.cancelAction { _ in
+            self.nameEditView.textField.becomeFirstResponder()
+        }
+        
+        return UIAlertController.cancel(
+            alertTitle: Text.cancelAlertTitle,
+            alertMessage: Text.cancelAlertMessage,
+            cancelAction: cancelAction
+        )
+    }
+    
+    /// 에러 발생시 나타나는 알림
+    private func fetchFailureAlert() -> UIAlertController {
+        let cancelAction = UIAlertAction.cancelAction { _ in
+            self.nameEditView.textField.becomeFirstResponder()
+        }
+        
+        return UIAlertController.cancel(
+            alertTitle: Text.errorAlertTitle,
+            alertMessage: Text.errorAlertMessage,
+            cancelAction: cancelAction
+        )
+    }
+    
+    
+    // MARK: - configurations
+    
+    /// 내비게이션 바의 왼쪽, 오른쪽 버튼 아이템 설정
+    private func configureNavigationItems() {
+        let cancel = UIBarButtonItem(
+            image: AssetImage.xmark,
+            style: .plain,
+            target: self,
+            action: #selector(cancelButtonDidTap)
+        )
+        let next = UIBarButtonItem(
+            image: AssetImage.checkmark,
+            style: .plain,
+            target: self,
+            action: #selector(saveButtonDidTap)
+        )
+        
+        self.navigationItem.leftBarButtonItem = cancel
+        self.navigationItem.rightBarButtonItem = next
+        self.navigationItem.title = Text.navigationBarTitle
+    }
+    
+    /// 텍스트필드 설정
+    private func configureTextField() {
+        self.nameEditView.textField.text = bottleData?.title
+        self.nameEditView.textField.delegate = self
+        self.nameEditView.textField.becomeFirstResponder()
+        self.nameEditView.textField.addTarget(
+            self,
+            action: #selector(self.textFieldDidChange(_:)),
+            for: .editingChanged
+        )
+    }
+}
+
+extension HomeBottleNameEditViewController: UITextFieldDelegate {
+    
+    func textFieldDidEndEditing(_ textField: UITextField) {
+        guard let text = textField.text,
+              text.count > Metric.maxLength
+        else { return }
+        
+        textField.text = String(text.prefix(Metric.maxLength))
+        self.nameEditView.textField.resignFirstResponder()
+    }
+    
+    /// 리턴 키를 눌렀을 때 자동으로 다음 뷰로 넘어가며, 텍스트필드의 firstResponder 해제
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        if let text = self.nameEditView.textField.text,
+           !text.isEmpty {
+            textField.endEditing(true)
+            self.present(self.confirmationAlert(), animated: true)
+            return true
+        } else {
+            HapticManager.instance.notification(type: .warning)
+            self.nameEditView.warningLabel.isHidden = false
+            self.nameEditView.warningLabel.fadeIn()
+        }
+        return false
+    }
+    
+    /// 최대 글자수 10자 제한
+    func textField(
+        _ textField: UITextField,
+        shouldChangeCharactersIn range: NSRange,
+        replacementString string: String
+    ) -> Bool {
+        
+        // 텍스트가 유효한지, 편집한 범위를 찾을 수 있는 지 확인
+        guard let currentText = textField.text,
+              Range(range, in: currentText) != nil
+        else { return false }
+        
+        let maxLength = Metric.maxLength + 1
+
+        let updatedTextLength = currentText.count - range.length + string.count
+        let trimLength = updatedTextLength - maxLength
+
+        guard updatedTextLength > maxLength,
+              string.count >= trimLength
+        else { return true }
+        
+        // 새로 입력된 문자열의 초과분을 삭제
+        let index = string.index(string.endIndex, offsetBy: -trimLength)
+        let trimmedReplacementText = string[..<index]
+        
+        guard let startPosition = textField.position(
+            from: textField.beginningOfDocument,
+            offset: range.location
+        ),
+              let endPosition = textField.position(
+                from: textField.beginningOfDocument,
+                offset: NSMaxRange(range)
+              ),
+              let textRange = textField.textRange(
+                from: startPosition,
+                to: endPosition
+              )
+        else { return false }
+              
+        textField.replace(textRange, withText: String(trimmedReplacementText))
+        
+        return false
+    }
+}
+
+// MARK: - Data Provider
+extension HomeBottleNameEditViewController: DataProvider {
+  func sendOriginalData(_ data: Bottle) {
+    self.bottleData = data
+  }
+}
+
+extension HomeBottleNameEditViewController {
+    enum Metric {
+        /// 저금통 이름의 최대 글자수(10자)
+        static let maxLength: Int = 10
+    }
+    
+    enum Text {
+        /// 내비게이션 바 타이틀
+        static let navigationBarTitle: String = "저금통 이름 변경"
+      
+        /// 생성 확인 알림 제목
+        static let confirmationAlertTitle = "저금통 이름을 변경하시겠어요?"
+        
+        /// 생성 확인 알림 내용
+        static let confirmationAlertMessage = "저금통 이름은 언제든 다시 변경할 수 있어요!"
+        
+        /// 생성 확인 알림 확인 버튼 제목: 추가
+        static let confirmationAlertConfirmButtonTitle = "변경"
+        
+        /// 생성 정보 부적합 알림 제목
+        static let cancelAlertTitle = "정보가 정상적으로 입력되지 않았습니다."
+        
+        /// 생성 정보 부적합 알림 내용
+        static let cancelAlertMessage = "저금통 이름을 다시 확인해주세요."
+        
+        /// 정보 저장 실패 알림 제목
+        static let errorAlertTitle: String = "변경사항 저장에 실패했습니다"
+        
+        /// 정보 저장 실패 알림 내용
+        static let errorAlertMessage: String = """
+        디바이스의 저장 공간이 충분한지 확인해주세요.
+        같은 문제가 계속 발생하는 경우 \(teamMail) 으로 문의 부탁드립니다.
+        """
+    }
+}

--- a/Happiggy-bank/Happiggy-bank/HomeTab/Home/UI/Controller/HomeTabViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/HomeTab/Home/UI/Controller/HomeTabViewController.swift
@@ -212,8 +212,13 @@ extension HomeTabViewController {
     
     /// 메뉴 버튼에서 저금통 제목 변경을 선택했을 때 실행되는 함수
     private func changeBottleNameItemDidTap() {
+        guard let currentBottle = viewModel.bottle
+        else { return }
+      
+        let nameEditViewController = HomeBottleNameEditViewController()
+        nameEditViewController.sendOriginalData(currentBottle)
         self.navigationController?.pushViewControllerWithFade(
-            to: UIViewController().then { $0.view.backgroundColor = .blue }
+            to: nameEditViewController
         )
         self.bottleViewController.alertOrModalDidAppear()
     }

--- a/Happiggy-bank/Happiggy-bank/HomeTab/Home/UI/View/BottleNameEditView.swift
+++ b/Happiggy-bank/Happiggy-bank/HomeTab/Home/UI/View/BottleNameEditView.swift
@@ -1,0 +1,127 @@
+//
+//  BottleNameEditView.swift
+//  Happiggy-bank
+//
+//  Created by 권은빈 on 2023/07/06.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class BottleNameEditView: UIView {
+
+    // MARK: - Properties
+    
+    /// 메인 라벨(저금통을 입력해주세요)
+    lazy var mainLabel: BaseLabel = BaseLabel().then {
+        $0.text = Text.mainLabel
+        $0.textColor = AssetColor.mainYellow
+        $0.changeFontSize(to: FontSize.body2)
+    }
+    
+    /// 설명 라벨(저금통은 나중에 변경할 수 있습니다)
+    lazy var descriptionLabel: BaseLabel = BaseLabel().then {
+        $0.text = Text.descriptionLabel
+        $0.textColor = AssetColor.subBrown02
+        $0.changeFontSize(to: FontSize.body4)
+    }
+    
+    /// 경고 라벨(저금통 이름이 없어요!)
+    lazy var warningLabel: BaseLabel = BaseLabel().then {
+        $0.text = Text.warningLabel
+        $0.textColor = AssetColor.etcAlert
+        $0.changeFontSize(to: FontSize.body4)
+        $0.isHidden = true
+    }
+    
+    /// 저금통 이름 입력할 텍스트필드
+    lazy var textField: BaseTextField = BaseTextField().then {
+        $0.placeholder = Text.placeholder
+        $0.layer.cornerRadius = Metric.cornerRadius
+        $0.backgroundColor = .white
+        $0.textAlignment = .center
+    }
+    
+    
+    // MARK: - override functions
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        self.backgroundColor = AssetColor.subGrayBG
+        configureSubviewsLayout()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    
+    // MARK: - configurations
+    
+    /// 뷰의 자식 뷰들 레이아웃 설정
+    private func configureSubviewsLayout() {
+        self.addSubviews([
+            self.mainLabel,
+            self.descriptionLabel,
+            self.warningLabel,
+            self.textField
+        ])
+        
+        self.mainLabel.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.top.equalToSuperview().offset(Metric.mainLabelTop)
+        }
+        
+        self.textField.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.top.equalTo(self.mainLabel.snp.bottom).offset(Metric.textFieldTop)
+            make.height.equalTo(Metric.textFieldHeight)
+            make.width.equalTo(self.textField.snp.height).multipliedBy(Metric.textFieldRatio)
+        }
+        
+        self.descriptionLabel.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.top.equalTo(self.textField.snp.bottom).offset(Metric.descriptionLabelTop)
+        }
+        
+        self.warningLabel.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.top.equalTo(self.descriptionLabel.snp.bottom).offset(Metric.warningLabelTop)
+        }
+    }
+}
+
+extension BottleNameEditView {
+    enum Text {
+        static let mainLabel: String = "저금통 이름을 입력해주세요"
+        
+        static let descriptionLabel: String = "저금통 이름은 나중에 변경할 수 있습니다"
+        
+        static let warningLabel: String = "저금통 이름이 없어요!"
+        
+        static let placeholder: String = "최대 10자까지 가능합니다"
+    }
+    
+    enum Metric {
+        static let cornerRadius: CGFloat = 7
+        
+        static let mainLabelTop: CGFloat = UIScreen.main.bounds.height * mainLabelTopRatio
+        
+        static let textFieldTop: CGFloat = 32
+        
+        static let descriptionLabelTop: CGFloat = 16
+        
+        static let warningLabelTop: CGFloat = 16
+        
+        static let textFieldHeight: CGFloat = 56
+        
+        static let textFieldRatio: CGFloat = 311 / 56
+        
+        static private let mainLabelTopRatio: CGFloat = 220 / 852
+    }
+}
+

--- a/Happiggy-bank/Happiggy-bank/Utils/Protocol/DataProvider.swift
+++ b/Happiggy-bank/Happiggy-bank/Utils/Protocol/DataProvider.swift
@@ -16,6 +16,9 @@ protocol DataProvider {
     
     /// 새 유리병 데이터를 전송하는 함수
     func send(_ data: NewBottle)
+  
+    /// 기존에 있던 유리병 데이터를 전송하는 함수
+    func sendOriginalData(_ data: Bottle)
 }
 
 // Optional Protocol을 위한 정의
@@ -25,4 +28,6 @@ extension DataProvider {
     func sendNewBottleData(_ data: NewBottle) { }
     
     func send(_ data: NewBottle) { }
+  
+    func sendOriginalData(_ data: Bottle) { }
 }


### PR DESCRIPTION
## 관련 이슈

- resolves #304 

## 작업 내용

HomeView의 오른쪽 위 버튼에서 접근할 수 있는 BottleNameEditViewController(저금통 이름 변경하는 뷰 컨트롤러) 리팩토링

### 클래스/메서드/swift 파일 이름 등

#### 새로 생성함
- BottleNameEditView
- HomeBottleNameEditViewController -> 기존에 BottleNameEditViewController를 일단 살려놓기 위해 Home을 붙였습니다.

#### 변경함
- HomeTabViewController
- DataProvider

## 리뷰 사항
X