### PR TITLE
[fix] D-day 라벨에 +,-가 중복으로 뜨는 현상 수정 #296

### DIFF
--- a/Happiggy-bank/Happiggy-bank/HomeTab/Home/ViewModel/HomeTabViewModel.swift
+++ b/Happiggy-bank/Happiggy-bank/HomeTab/Home/ViewModel/HomeTabViewModel.swift
@@ -69,11 +69,16 @@ final class HomeTabViewModel {
         )
         guard let days = daysCount.day
         else { return nil }
-        
-        if days >= 0 {
-            return "D-\(days)"
-        } else {
-            return "D+\(days)"
+      
+        switch days {
+        case 0:
+          return "D-Day"
+        case Int.min ... -1:
+          return "D+\(-1 * days)"
+        case 1 ... Int.max:
+          return "D-\(days)"
+        default:
+          return nil
         }
     }
     


### PR DESCRIPTION
## 관련 이슈

- resolves #296 

## 작업 내용

D-Day가 지난 날부터 숫자 앞에 - 라벨이 붙는 현상 수정

### 클래스/메서드/swift 파일 이름 등

- HomeTabViewModel 변경

## 리뷰 사항

X
