### PR TITLE
[refactor] 로컬 노티피케이션 관련 코드 리팩토링 #306

### DIFF
--- a/Happiggy-bank/Happiggy-bank.xcodeproj/project.pbxproj
+++ b/Happiggy-bank/Happiggy-bank.xcodeproj/project.pbxproj
@@ -172,6 +172,9 @@
 		A8D58DB229928AA900FD52A1 /* NewBottleDateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8D58DB129928AA900FD52A1 /* NewBottleDateViewController.swift */; };
 		A8EB5E8B27C8B087005704F2 /* UIButton+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8EB5E8A27C8B087005704F2 /* UIButton+Extension.swift */; };
 		A8ECD4A727E33BFA00886BC0 /* ListTabViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8ECD4A627E33BFA00886BC0 /* ListTabViewModel.swift */; };
+		A8F6821F2A70F81700DA692E /* NotificationSettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8F6821E2A70F81700DA692E /* NotificationSettingViewController.swift */; };
+		A8F682212A70F87000DA692E /* NotificationSettingTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8F682202A70F87000DA692E /* NotificationSettingTableViewCell.swift */; };
+		A8F682232A78FC9100DA692E /* NotificationSettingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8F682222A78FC9100DA692E /* NotificationSettingViewModel.swift */; };
 		A8F985E0296FDE6000E5ACC6 /* ListTabViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8F985DF296FDE6000E5ACC6 /* ListTabViewController.swift */; };
 		A8F985E2296FF37000E5ACC6 /* BottleCollectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8F985E1296FF37000E5ACC6 /* BottleCollectionCell.swift */; };
 		A8FC07C827B3ECF00077A758 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8FC07C727B3ECF00077A758 /* AppDelegate.swift */; };
@@ -353,6 +356,9 @@
 		A8D58DB129928AA900FD52A1 /* NewBottleDateViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewBottleDateViewController.swift; sourceTree = "<group>"; };
 		A8EB5E8A27C8B087005704F2 /* UIButton+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+Extension.swift"; sourceTree = "<group>"; };
 		A8ECD4A627E33BFA00886BC0 /* ListTabViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListTabViewModel.swift; sourceTree = "<group>"; };
+		A8F6821E2A70F81700DA692E /* NotificationSettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSettingViewController.swift; sourceTree = "<group>"; };
+		A8F682202A70F87000DA692E /* NotificationSettingTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSettingTableViewCell.swift; sourceTree = "<group>"; };
+		A8F682222A78FC9100DA692E /* NotificationSettingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSettingViewModel.swift; sourceTree = "<group>"; };
 		A8F985DF296FDE6000E5ACC6 /* ListTabViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListTabViewController.swift; sourceTree = "<group>"; };
 		A8F985E1296FF37000E5ACC6 /* BottleCollectionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottleCollectionCell.swift; sourceTree = "<group>"; };
 		A8FC07C427B3ECF00077A758 /* Happiggy-bank.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Happiggy-bank.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -967,6 +973,7 @@
 			isa = PBXGroup;
 			children = (
 				D22ADF7E27F72F7300ECB77B /* NotificationSettingsViewModel.swift */,
+				A8F682222A78FC9100DA692E /* NotificationSettingViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -984,6 +991,7 @@
 			isa = PBXGroup;
 			children = (
 				D22ADF6227F5CE8F00ECB77B /* NotificationSettingsViewController.swift */,
+				A8F6821E2A70F81700DA692E /* NotificationSettingViewController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -993,6 +1001,7 @@
 			children = (
 				A439F53B27EEFCF6002851F4 /* NotificationToggleCell.swift */,
 				A804425C28FEA27700EF2CE3 /* NotificationToggleCell.xib */,
+				A8F682202A70F87000DA692E /* NotificationSettingTableViewCell.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -1432,9 +1441,9 @@
 				A819CF9F27DDD97C00DE8E72 /* HapticManager.swift in Sources */,
 				A4569CCF28128B4B001E3FD6 /* SettingsNonIconButtonCell.swift in Sources */,
 				A4396B1B29325D70005D9D3A /* PhotoViewController.swift in Sources */,
+				A8F6821F2A70F81700DA692E /* NotificationSettingViewController.swift in Sources */,
 				A8ECD4A727E33BFA00886BC0 /* ListTabViewModel.swift in Sources */,
-				A49AC5EB2917FFAB009315BC /* PhotoNoteCellViewModel.swift in Sources */,
-				A8ECD4A727E33BFA00886BC0 /* BottleListViewModel.swift in Sources */,
+				A8ECD4A727E33BFA00886BC0 /* ListTabViewModel.swift in Sources */,
 				A484A32B296004E600A58312 /* Version.swift in Sources */,
 				A46B2E7729B493D7006A7870 /* LabeledCollectionView.swift in Sources */,
 				A85B38882990D5F000ED8C72 /* NewBottleNameViewController.swift in Sources */,
@@ -1477,6 +1486,7 @@
 				A41DE62E27F5F2C1002A7669 /* UIView+ZoomAnimation.swift in Sources */,
 				A4D6EB7B2837825500553E43 /* LookUpResult.swift in Sources */,
 				A439F54527EF0698002851F4 /* SettingsLabelButtonCell.swift in Sources */,
+				A8F682232A78FC9100DA692E /* NotificationSettingViewModel.swift in Sources */,
 				A484A3032958936300A58312 /* BaseLabel.swift in Sources */,
 				A484A320295D7B2A00A58312 /* Requestable.swift in Sources */,
 				A41A506F27FF2B2E005381EF /* CustomTabBar.swift in Sources */,
@@ -1533,6 +1543,7 @@
 				A4845B5D2900DF0B00A6007C /* ColorPicker.swift in Sources */,
 				A49AC5E72917CB47009315BC /* UIView+AddSubviews.swift in Sources */,
 				A89CBEDD27CBDEA2005549F6 /* BottleListViewController.swift in Sources */,
+				A8F682212A70F87000DA692E /* NotificationSettingTableViewCell.swift in Sources */,
 				A439F53A27EEFC28002851F4 /* SettingsViewCell.swift in Sources */,
 				A46B10F62814458C004AB185 /* UILabel+ChangeOnlyFontFamily.swift in Sources */,
 				A4569CBA280FBA23001E3FD6 /* CustomResult.swift in Sources */,

--- a/Happiggy-bank/Happiggy-bank/SettingsTab/Notification/UI/Controller/NotificationSettingViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/SettingsTab/Notification/UI/Controller/NotificationSettingViewController.swift
@@ -1,0 +1,308 @@
+//
+//  NotificationSettingViewController.swift
+//  Happiggy-bank
+//
+//  Created by 권은빈 on 2023/07/26.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class NotificationSettingViewController: UIViewController {
+    
+    private var viewModel = NotificationSettingViewModel()
+    
+    private let tableView = UITableView().then {
+        $0.rowHeight = Metric.rowHeight
+        $0.separatorStyle = .none
+        $0.isScrollEnabled = false
+        $0.showsVerticalScrollIndicator = false
+    }
+    
+    
+    // MARK: - Life Cycle
+    
+    override func loadView() {
+        self.view = tableView
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureTableView()
+        registerCells()
+        configureNavigationBar()
+    }
+    
+    
+    // MARK: - @objc functions
+    
+    /// 알림 토글 버튼에 변화가 있을 때 호출되는 objc 함수
+    @objc private func toggleButtonDidTap(_ sender: UISwitch) {
+        let indexPath = [IndexPath(row: sender.tag, section: 0)]
+        let content = NotificationSettingViewModel.Content.allCases[sender.tag]
+        
+        if sender.isOn {
+            requestNotification(of: content) {
+                self.viewModel.scheduleNotifications(of: content)
+                DispatchQueue.main.async {
+                    if content == .reminder && self.viewModel.canUpdateRemindNotification == false {
+                        self.notificationSettingDisabledAlert(of: content)
+                    }
+                    self.tableView.reloadRows(at: indexPath, with: .automatic)
+                }
+            }
+            return
+        }
+        if !sender.isOn {
+            viewModel.removeNotifications(of: content)
+            tableView.reloadRows(at: indexPath, with: .automatic)
+        }
+    }
+    
+    // MARK: - 시간 설정하는 데이트피커가 일일 알림 외에 다른 알림에도 붙을 때 코드 수정 필요
+    /// 시간을 설정하는 데이트피커에 변화가 있을 때 호출되는 objc 함수
+    @objc private func timePickerDidChanged(_ sender: UIDatePicker) {
+        let indexPath = [IndexPath(row: sender.tag, section: 0)]
+        
+        viewModel.dailyNotificationTime = sender.date
+        viewModel.removeNotifications(of: .daily)
+        viewModel.scheduleNotifications(of: .daily)
+        
+        UserDefaults.standard.set(
+            sender.date,
+            forKey: NotificationSettingViewModel.Content.datePickerUserDefaultsKey
+        )
+        tableView.reloadRows(at: indexPath, with: .automatic)
+    }
+    
+    private func configureTableView() {
+        tableView.dataSource = self
+        tableView.register(
+            NotificationSettingTableViewCell.self,
+            forCellReuseIdentifier: NotificationSettingTableViewCell.name
+        )
+    }
+    
+    private func configureNavigationBar() {
+        self.navigationItem.backButtonTitle = .empty
+        self.navigationController?.navigationBar.clear()
+        self.navigationItem.title = StringLiteral.navigationTitle
+    }
+    
+    
+    // MARK: - Functions
+    
+    /// 테이블 뷰 셀 등록
+    private func registerCells() {
+        self.tableView.register(
+            UINib(nibName: NotificationToggleCell.name, bundle: nil),
+            forCellReuseIdentifier: NotificationToggleCell.name
+        )
+    }
+    
+    /// 노티피케이션 요청
+    private func requestNotification(
+        of content: NotificationSettingViewModel.Content,
+        _ completionHandler: @escaping () -> Void
+    ) {
+        self.viewModel.notificationCenter.requestAuthorization(
+            options: [.alert, .sound]
+        ) { granted, error in
+        
+            if let error = error {
+                print(error.localizedDescription)
+            }
+            
+            if !granted {
+                UserDefaults.standard.set(false, forKey: content.userDefaultsKey)
+                DispatchQueue.main.async {
+                    self.notificationSettingDisabledAlert(of: content)
+                }
+            } else {
+                UserDefaults.standard.set(true, forKey: content.userDefaultsKey)
+            }
+            
+            completionHandler()
+        }
+    }
+    
+    /// 설정에서 알림 꺼져있을 때 나타내는 알림창
+    private func notificationSettingDisabledAlert(
+        of content: NotificationSettingViewModel.Content
+    ) {
+        var alertTitle: String
+        var alertMessage: String
+        var action: UIAlertAction
+        
+        switch content {
+        case .daily:
+            alertTitle = StringLiteral.disabledAlertTitle
+            alertMessage = StringLiteral.disabledAlertMessage
+            action = UIAlertAction(
+                title: StringLiteral.moveToSettings,
+                style: .default
+            ) { _ in
+                self.openSettings()
+            }
+        case .reminder:
+            alertTitle = StringLiteral.reminderDisabledAlertTitle
+            alertMessage = StringLiteral.reminderDisabledAlertMessage
+            action = UIAlertAction(
+                title: StringLiteral.moveToHome,
+                style: .default
+            ) { _ in
+                self.moveToHomeView()
+            }
+        }
+        
+        let alert = UIAlertController(
+            title: alertTitle,
+            message: alertMessage,
+            preferredStyle: .alert
+        )
+        alert.addAction(action)
+        self.present(alert, animated: false)
+    }
+    
+    /// 설정으로 이동
+    private func openSettings() {
+        if let bundle = Bundle.main.bundleIdentifier,
+           let settings = URL(string: UIApplication.openSettingsURLString + bundle) {
+            if UIApplication.shared.canOpenURL(settings) {
+                UIApplication.shared.open(settings)
+            }
+        }
+    }
+    
+    /// 홈 화면으로 이동
+    private func moveToHomeView() {
+        self.tabBarController?.selectedIndex = 0
+    }
+}
+
+extension NotificationSettingViewController: UITableViewDataSource {
+    func tableView(
+        _ tableView: UITableView,
+        numberOfRowsInSection section: Int
+    ) -> Int {
+        NotificationSettingViewModel.Content.allCases.count
+    }
+    
+    func tableView(
+        _ tableView: UITableView,
+        cellForRowAt indexPath: IndexPath
+    ) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(
+            withIdentifier: NotificationSettingTableViewCell.name,
+            for: indexPath
+        ) as? NotificationSettingTableViewCell ?? NotificationSettingTableViewCell()
+        let index = indexPath.row
+        let allCases = NotificationSettingViewModel.Content.allCases
+        
+        clearCellBeforeReuse(cell)
+        
+        cell.titleLabel.text = allCases[index].title
+        cell.timePicker.isHidden = viewModel.shouldHideTimePicker(of: allCases[index])
+        cell.toggleButton.isOn = viewModel.shouldToggleButtonOn(of: allCases[index])
+        cell.timePicker.tag = index
+        cell.toggleButton.tag = index
+        
+        configureNotificationCellActions(of: index, cell.toggleButton, cell.timePicker)
+        
+        return cell
+    }
+    
+    
+    // MARK: - Configure Cell
+    
+    private func clearCellBeforeReuse(_ cell: NotificationSettingTableViewCell) {
+        cell.titleLabel.text = .empty
+        cell.timePicker.isHidden = true
+        cell.toggleButton.isOn = false
+        cell.toggleButton.tag = 0
+    }
+    
+    private func configureNotificationCellActions(
+        of index: Int,
+        _ button: UISwitch,
+        _ timePicker: UIDatePicker
+    ) {
+        
+        button.addTarget(self, action: #selector(toggleButtonDidTap), for: .valueChanged)
+        
+        switch NotificationSettingViewModel.Content.allCases[index] {
+        case .daily:
+            timePicker.addTarget(self, action: #selector(timePickerDidChanged), for: .valueChanged)
+            
+            viewModel.notificationCenter.getNotificationSettings { settings in
+                guard settings.authorizationStatus == .authorized
+                else {
+                    DispatchQueue.main.async {
+                        button.isOn = false
+                        timePicker.isHidden = true
+                    }
+                    return
+                }
+                
+                DispatchQueue.main.async {
+                    button.isOn = self.viewModel.shouldToggleButtonOn(of: .daily)
+                    timePicker.isHidden = self.viewModel.shouldHideTimePicker(of: .daily)
+                    timePicker.date = UserDefaults.standard.object(
+                        forKey: NotificationSettingViewModel.Content.datePickerUserDefaultsKey
+                    ) as? Date ?? Date()
+                }
+            }
+        case .reminder:
+            viewModel.notificationCenter.getNotificationSettings { settings in
+                guard settings.authorizationStatus == .authorized,
+                      self.viewModel.endDate != nil,
+                      self.viewModel.canUpdateRemindNotification != false
+                else {
+                    DispatchQueue.main.async {
+                        button.isOn = false
+                    }
+                    return
+                }
+                
+                DispatchQueue.main.async {
+                    button.isOn = self.viewModel.shouldToggleButtonOn(of: .reminder)
+                }
+            }
+        }
+    }
+}
+
+extension NotificationSettingViewController {
+    
+    enum Metric {
+        static let rowHeight: CGFloat = 67
+    }
+    
+    enum StringLiteral {
+        /// 내비게이션 타이틀
+        static let navigationTitle = "알림 설정"
+        
+        /// 알림 타이틀
+        static let disabledAlertTitle: String = "알림을 허용해주세요."
+        
+        /// 알림 메시지
+        static let disabledAlertMessage: String = "알림을 받으려면 시스템 설정에서 행복저금통 알림을 허용해주세요."
+        
+        /// 알림 이동 액션 라벨
+        static let moveToSettings: String = "설정으로 이동"
+        
+        /// 알림 취소 액션 라벨
+        static let cancel: String = "취소"
+        
+        /// 리마인드 알림 불가시 알림 타이틀
+        static let reminderDisabledAlertTitle: String = "저금통이 없어요!"
+        
+        /// 리마인드 알림 불가시 알림 메시지
+        static let reminderDisabledAlertMessage: String = "리마인드 알림을 받으려면 저금통을 생성해주세요."
+        
+        /// 홈 화면으로 이동
+        static let moveToHome: String = "만들러 가기"
+    }
+}

--- a/Happiggy-bank/Happiggy-bank/SettingsTab/Notification/UI/View/NotificationSettingTableViewCell.swift
+++ b/Happiggy-bank/Happiggy-bank/SettingsTab/Notification/UI/View/NotificationSettingTableViewCell.swift
@@ -67,13 +67,6 @@ final class NotificationSettingTableViewCell: UITableViewCell {
         initializeLayout()
     }
     
-    override func prepareForReuse() {
-        super.prepareForReuse()
-        
-        titleLabel.text = .empty
-        timePicker.isHidden = true
-        toggleButton.isOn = false
-    }
     
     private func initializeLayout() {
         self.contentView.addSubview(contentAndSeparatorStackView)

--- a/Happiggy-bank/Happiggy-bank/SettingsTab/Notification/UI/View/NotificationSettingTableViewCell.swift
+++ b/Happiggy-bank/Happiggy-bank/SettingsTab/Notification/UI/View/NotificationSettingTableViewCell.swift
@@ -12,7 +12,7 @@ import Then
 
 final class NotificationSettingTableViewCell: UITableViewCell {
   
-    let cellContentView: UIView = UIView()
+    private let cellContentView: UIView = UIView()
     
     var title: String? {
         get { self.titleLabel.text }

--- a/Happiggy-bank/Happiggy-bank/SettingsTab/Notification/UI/View/NotificationSettingTableViewCell.swift
+++ b/Happiggy-bank/Happiggy-bank/SettingsTab/Notification/UI/View/NotificationSettingTableViewCell.swift
@@ -1,0 +1,111 @@
+//
+//  NotificationSettingTableViewCell.swift
+//  Happiggy-bank
+//
+//  Created by 권은빈 on 2023/07/26.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class NotificationSettingTableViewCell: UITableViewCell {
+  
+    let cellContentView: UIView = UIView()
+    
+    var title: String? {
+        get { self.titleLabel.text }
+        set { self.titleLabel.text = newValue }
+    }
+    
+    var time: Date? {
+        get { self.timePicker.date }
+        set { self.timePicker.date = newValue ?? Date() }
+    }
+    
+    lazy var titleLabel: BaseLabel = BaseLabel().then {
+        $0.changeFontSize(to: FontSize.body3)
+    }
+    
+    lazy var timePicker: UIDatePicker = UIDatePicker().then {
+        $0.datePickerMode = .time
+        $0.preferredDatePickerStyle = .compact
+        $0.isHidden = true
+    }
+    
+    lazy var toggleButton: UISwitch = UISwitch().then {
+        $0.isOn = false
+        $0.onTintColor = .customTint
+    }
+    
+    private let contentAndSeparatorStackView = UIStackView().then {
+        $0.axis = .vertical
+        $0.translatesAutoresizingMaskIntoConstraints = false
+    }
+
+    private let separator = UIView().then {
+        $0.backgroundColor = AssetColor.etcBorderGray
+        $0.snp.makeConstraints { make in
+            make.height.equalTo(Metric.separatorHeight)
+        }
+    }
+    
+    // MARK: - Init(s)
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+
+        self.selectionStyle = .none
+        initializeLayout()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+
+        self.selectionStyle = .none
+        initializeLayout()
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        
+        titleLabel.text = .empty
+        timePicker.isHidden = true
+        toggleButton.isOn = false
+    }
+    
+    private func initializeLayout() {
+        self.contentView.addSubview(contentAndSeparatorStackView)
+        self.cellContentView.addSubviews(titleLabel, toggleButton, timePicker)
+        self.contentAndSeparatorStackView.addArrangedSubviews(cellContentView, separator)
+        
+        titleLabel.snp.makeConstraints { make in
+            make.leading.equalToSuperview().offset(Metric.cellHorizontalPadding)
+            make.centerY.equalToSuperview()
+        }
+        
+        toggleButton.snp.makeConstraints { make in
+            make.trailing.equalToSuperview().offset(-Metric.cellHorizontalPadding)
+            make.centerY.equalToSuperview()
+        }
+        
+        timePicker.snp.makeConstraints { make in
+            make.trailing.equalTo(toggleButton.snp.leading).offset(-Metric.cellHorizontalPadding)
+            make.centerY.equalToSuperview()
+        }
+        
+        contentAndSeparatorStackView.snp.makeConstraints { make in
+            make.verticalEdges.equalToSuperview()
+            make.horizontalEdges.equalToSuperview().inset(Metric.inset)
+        }
+    }
+}
+
+extension NotificationSettingTableViewCell {
+    enum Metric {
+        static let separatorHeight: CGFloat = 1
+        static let cellHorizontalPadding: CGFloat = 10
+        static let inset: CGFloat = 24
+    }
+}

--- a/Happiggy-bank/Happiggy-bank/SettingsTab/Notification/ViewModel/NotificationSettingViewModel.swift
+++ b/Happiggy-bank/Happiggy-bank/SettingsTab/Notification/ViewModel/NotificationSettingViewModel.swift
@@ -13,7 +13,7 @@ final class NotificationSettingViewModel {
     let notificationCenter = UNUserNotificationCenter.current()
     
     /// UserDefaults
-    let userDefaults = UserDefaults.standard
+    private let userDefaults = UserDefaults.standard
     
     /// 저금통이 끝나는 날짜
     lazy var endDate: Date? = {

--- a/Happiggy-bank/Happiggy-bank/SettingsTab/Notification/ViewModel/NotificationSettingViewModel.swift
+++ b/Happiggy-bank/Happiggy-bank/SettingsTab/Notification/ViewModel/NotificationSettingViewModel.swift
@@ -18,8 +18,8 @@ final class NotificationSettingViewModel {
     /// 저금통이 끝나는 날짜
     lazy var endDate: Date? = {
         let request = Bottle.fetchRequest(isOpen: false)
-        let bottles = PersistenceStore.shared.fetchOld(request: request)
-        guard let bottle = bottles.first
+        guard let bottles = try? PersistenceStore.shared.fetch(request: request).get(),
+              let bottle = bottles.first
         else { return nil }
         return bottle.endDate
     }()
@@ -134,8 +134,8 @@ final class NotificationSettingViewModel {
     
     private func fetchBottleEndDate() {
         let request = Bottle.fetchRequest(isOpen: false)
-        let bottles = PersistenceStore.shared.fetchOld(request: request)
-        guard let bottle = bottles.first
+        guard let bottles = try? PersistenceStore.shared.fetch(request: request).get(),
+              let bottle = bottles.first
         else {
             self.canUpdateRemindNotification = false
             return

--- a/Happiggy-bank/Happiggy-bank/SettingsTab/Notification/ViewModel/NotificationSettingViewModel.swift
+++ b/Happiggy-bank/Happiggy-bank/SettingsTab/Notification/ViewModel/NotificationSettingViewModel.swift
@@ -1,0 +1,263 @@
+//
+//  NotificationSettingViewModel.swift
+//  Happiggy-bank
+//
+//  Created by 권은빈 on 2023/08/01.
+//
+
+import UserNotifications
+
+final class NotificationSettingViewModel {
+    
+    /// UserNotificationCenter
+    let notificationCenter = UNUserNotificationCenter.current()
+    
+    /// UserDefaults
+    let userDefaults = UserDefaults.standard
+    
+    /// 저금통이 끝나는 날짜
+    lazy var endDate: Date? = {
+        let request = Bottle.fetchRequest(isOpen: false)
+        let bottles = PersistenceStore.shared.fetchOld(request: request)
+        guard let bottle = bottles.first
+        else { return nil }
+        return bottle.endDate
+    }()
+    
+    /// 일일 알림이 설정된 시간
+    lazy var dailyNotificationTime: Date? = UserDefaults.standard.object(
+        forKey: Content.datePickerUserDefaultsKey
+    ) as? Date
+    
+    /// 리마인드 알림을 설정할 수 있는지 없는지 판단하는 Bool값
+    lazy var canUpdateRemindNotification: Bool? = {
+        return self.endDate != nil
+    }()
+    
+    
+    // MARK: - Function
+    
+    /// 토글 버튼의 활성화 여부
+    func shouldToggleButtonOn(of content: Content) -> Bool {
+        return userDefaults.bool(forKey: content.userDefaultsKey)
+    }
+    
+    /// 타임피커 숨겨야 하는지 여부
+    func shouldHideTimePicker(of content: Content) -> Bool {
+        switch content {
+        case .daily:
+            return !shouldToggleButtonOn(of: content)
+        case .reminder:
+            return true
+        }
+    }
+    
+    /// day만큼 반복되는 DateComponents 만드는 함수
+    func repeatingDateComponent(byAdding day: Int) -> DateComponents {
+        if let endDate = endDate,
+           let repeatingDate = Calendar.current.date(
+            byAdding: DateComponents(day: day),
+            to: endDate
+        ) {
+            return Calendar.current.dateComponents(
+                [.year, .month, .day, .hour, .minute],
+                from: repeatingDate
+            )
+        }
+        return DateComponents()
+    }
+    
+    /// 노티피케이션 스케줄링
+    func scheduleNotifications(of content: Content) {
+        
+        fetchBottleEndDate()
+        
+        self.notificationCenter.getNotificationSettings { [weak self] settings in
+            guard let self = self
+            else { return }
+            
+            switch content {
+            case .daily:
+                guard settings.authorizationStatus == .authorized
+                else { return }
+                let request = self.notificationRequest(at: self.dailyNotificationTime)
+                self.notificationCenter.add(request) { error in
+                    if let error = error {
+                        print(error.localizedDescription)
+                    }
+                }
+            case .reminder:
+                guard settings.authorizationStatus == .authorized,
+                      self.endDate != nil
+                else {
+                    self.canUpdateRemindNotification = false
+                    return
+                }
+                for day in 0...Metric.repeatingDays {
+                    let request = self.notificationRequest(byAdding: day)
+                    self.notificationCenter.add(request) { error in
+                        if let error = error {
+                            print(error.localizedDescription)
+                        }
+                    }
+                }
+            }
+            
+            self.userDefaults.set(true, forKey: content.userDefaultsKey)
+            self.userDefaults.set(self.dailyNotificationTime, forKey: Content.datePickerUserDefaultsKey)
+        }
+    }
+    
+    /// 전달된, 대기중인 모든 노티피케이션 삭제
+    func removeNotifications(of content: Content) {
+        switch content {
+        case .daily:
+            self.notificationCenter.removeDeliveredNotifications(
+                withIdentifiers: [content.notificationIdentifier]
+            )
+            self.notificationCenter.removePendingNotificationRequests(
+                withIdentifiers: [content.notificationIdentifier]
+            )
+        case .reminder:
+            if self.endDate == nil { break }
+            for day in 0...Metric.repeatingDays {
+                self.notificationCenter.removeDeliveredNotifications(
+                    withIdentifiers: [content.notificationIdentifier + "\(day)"]
+                )
+                self.notificationCenter.removePendingNotificationRequests(
+                    withIdentifiers: [content.notificationIdentifier + "\(day)"]
+                )
+            }
+        }
+        userDefaults.set(false, forKey: content.userDefaultsKey)
+    }
+    
+    private func fetchBottleEndDate() {
+        let request = Bottle.fetchRequest(isOpen: false)
+        let bottles = PersistenceStore.shared.fetchOld(request: request)
+        guard let bottle = bottles.first
+        else {
+            self.canUpdateRemindNotification = false
+            return
+        }
+        
+        self.endDate = bottle.endDate
+        self.canUpdateRemindNotification = nil
+    }
+    
+    /// 일일 알림 리퀘스트 만들어주는 함수
+    private func notificationRequest(at time: Date?) -> UNNotificationRequest {
+        let content = UNMutableNotificationContent()
+        let trigger = UNCalendarNotificationTrigger(
+            dateMatching: Calendar.current.dateComponents(
+                [.hour, .minute],
+                from: time == nil ? Date() : time!
+            ),
+            repeats: true
+        )
+        content.title = Content.daily.message.title
+        content.body = Content.daily.message.body
+        content.sound = .default
+        
+        return UNNotificationRequest(
+            identifier: Content.daily.notificationIdentifier,
+            content: content,
+            trigger: trigger
+        )
+    }
+    
+    /// 리마인드 알림 리퀘스트 만들어주는 함수
+    private func notificationRequest(byAdding day: Int) -> UNNotificationRequest {
+        let content = UNMutableNotificationContent()
+        let trigger = UNCalendarNotificationTrigger(
+            dateMatching: self.repeatingDateComponent(byAdding: day),
+            repeats: false
+        )
+        content.title = Content.reminder.message.title
+        content.body = Content.reminder.message.body
+        content.sound = .default
+        
+        return UNNotificationRequest(
+            identifier: Content.reminder.notificationIdentifier + "\(day)",
+            content: content,
+            trigger: trigger
+        )
+    }
+    
+    // MARK: Function for Debug Notifications
+    
+    /// pending, delivered된 노티피케이션 출력하는 유틸리티 함수
+    fileprivate func printNotifications() {
+        self.notificationCenter.getPendingNotificationRequests { requests in
+            print("++++pending requests++++")
+            print(requests)
+            print("-----------------------")
+        }
+        self.notificationCenter.getDeliveredNotifications { notifications in
+            print("****delivered notifications****")
+            print(notifications)
+            print("-------------------------------")
+        }
+    }
+}
+
+extension NotificationSettingViewModel {
+    
+    /// 상수값
+    enum Metric {
+        
+        /// 노티피케이션 반복할 날짜
+        static let repeatingDays: Int = 3
+    }
+
+    /// 각 셀 별 내용
+    enum Content: Int, CaseIterable {
+        /// 일일 알림 설정
+        case daily
+        /// 리마인드 알림 설정
+        case reminder
+        
+        /// 노티피케이션 시간을 저장하는 userDefaults 데이터의 key
+        static let datePickerUserDefaultsKey: String = "timePickerDate"
+        
+        /// 제목
+        internal var title: String {
+            switch self {
+            case .daily:
+                return "일일 알림"
+            case .reminder:
+                return "리마인드 알림"
+            }
+        }
+        
+        /// userDefault key
+        internal var userDefaultsKey: String {
+            switch self {
+            case .daily:
+                return "dailyNotification"
+            case .reminder:
+                return "remindNotification"
+            }
+        }
+        
+        /// NotificationCenter의 식별자
+        internal var notificationIdentifier: String {
+            switch self {
+            case .daily:
+                return "dailyNotification"
+            case .reminder:
+                return "remindNotification"
+            }
+        }
+        
+        /// Alert에 대한 title과 body
+        internal var message: (title: String, body: String) {
+            switch self {
+            case .daily:
+                return ("오늘의 기분은?", "오늘 느낀 행복을 저장해보세요 :)")
+            case .reminder:
+                return ("행복한 소식!", "저금통을 열어볼 준비가 되었어요 :)")
+            }
+        }
+    }
+}

--- a/Happiggy-bank/Happiggy-bank/SettingsTab/Tab/UI/Controller/SettingsViewController.swift
+++ b/Happiggy-bank/Happiggy-bank/SettingsTab/Tab/UI/Controller/SettingsViewController.swift
@@ -143,7 +143,7 @@ extension SettingsViewController: UITableViewDelegate {
 
         switch rowType {
         case .alert:
-            self.show(tempVC, sender: self)
+            self.show(NotificationSettingViewController(), sender: self)
         case .version:
             self.openAppStoreIfNeeded()
             return


### PR DESCRIPTION
## 관련 이슈

- resolves #306 

## 작업 내용

로컬 노티피케이션 관련 코드 리팩토링 진행.

로컬 노티가 늘거나 혹은 푸시 노티를 추가해야할 때 이에 대한 설정 정보(알림 on/off, 시간 등)를 따로 DB에 저장해야하나 생각했는데 데이터 저장소 관련해서 아티클 몇 개 읽고 생각해봤을 때 그냥 UserDefaults 쓰는 것이 가장 합리적인 것 같아서 일단 이대로 진행했습니다.

### NotificationSettingViewController
- NotificationSettingsViewController의 내용을 변경했습니다.
- 중복되는 코드를 줄였습니다.

### NotificationSettingViewModel
- NotificationSettingsViewModel의 내용을 변경했습니다.
- 알림이 더 늘어나도 Content에 추가하면 됩니다. (단, 타임피커 관련 코드는 일부 수정해야 함)

### NotificationSettingTableViewCell
- NotificationToggleCell의 내용을 변경했습니다.

### SettingsViewController
- NotificationSettingViewController 객체 생성하는 부분을 추가했습니다.


## 리뷰 사항

- [ ] 일일 알림에 타임 피커가 있는데, 이것도 폰트가 변경될 때 같이 변경되어야 하나요?
- [ ] 가능하다면 QA 한번 부탁드릴게요! 제가 했을 땐 일단 잘 됐지만 혹시 몰라서요.
- [ ] SettingsVC - 세팅 enum에서 로컬 노티 관련 케이스 이름이 alert인데 약간 모호한 것 같긴 한데 어떻게 생각하세요? UIAlert인줄 알고 처음에 찾기가 좀 어려웠는데 또 notification이라고 하기엔 NotificationCenter랑 겹칠 것 같고... 라는 생각이 듭니다.
